### PR TITLE
Fix next lint failing in CI

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,0 +1,14 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [...compat.extends("next/core-web-vitals")];
+
+export default eslintConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint --dir ."
   },
   "dependencies": {
     "@radix-ui/react-slot": "latest",
@@ -25,6 +25,7 @@
     "@types/node": "^22.13.4",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
+    "@eslint/eslintrc": "^3.2.0",
     "eslint": "^9.20.0",
     "eslint-config-next": "16.1.7",
     "postcss": "^8.4.49",


### PR DESCRIPTION
## Summary
- Create `eslint.config.mjs` with `next/core-web-vitals` via FlatCompat so `next lint` runs non-interactively in CI
- Add `@eslint/eslintrc` devDependency for the compat layer
- Update lint script to `next lint --dir .` to prevent path misinterpretation

## Test plan
- [ ] `frontend-build` CI job passes the lint step
- [ ] `npm run lint` works locally