### PR TITLE
Add structured filtering to node list

### DIFF
--- a/backend/app/api/routes/nodes.py
+++ b/backend/app/api/routes/nodes.py
@@ -53,13 +53,21 @@ async def nodes_list(
     team_id: uuid.UUID,
     q: str | None = None,
     parent_id: uuid.UUID | None = Query(default=None),
+    kind: list[str] | None = Query(default=None),
+    has_url: bool | None = Query(default=None),
+    tags: list[str] | None = Query(default=None),
+    is_orphan: bool | None = Query(default=None),
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> list[Node]:
     await require_role(db, user=user, team_id=team_id, min_role="viewer")
-    return await list_nodes(db, team_id=team_id, q=q, parent_id=parent_id, limit=limit, offset=offset)
+    return await list_nodes(
+        db, team_id=team_id, q=q, parent_id=parent_id,
+        kind=kind, has_url=has_url, tags=tags, is_orphan=is_orphan,
+        limit=limit, offset=offset,
+    )
 
 
 @router.post("", response_model=NodePublic, status_code=201)

--- a/backend/app/services/nodes.py
+++ b/backend/app/services/nodes.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 import uuid
 
-from sqlalchemy import delete as sa_delete, func, or_, select, text
+from sqlalchemy import cast, delete as sa_delete, func, or_, select, text
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.node import Node
@@ -16,6 +17,10 @@ async def list_nodes(
     team_id: uuid.UUID,
     q: str | None = None,
     parent_id: uuid.UUID | None = None,
+    kind: list[str] | None = None,
+    has_url: bool | None = None,
+    tags: list[str] | None = None,
+    is_orphan: bool | None = None,
     limit: int = 50,
     offset: int = 0,
 ) -> list[Node]:
@@ -32,6 +37,18 @@ async def list_nodes(
                 Node.url.ilike(like),
             )
         )
+    if kind:
+        stmt = stmt.where(Node.kind.in_(kind))
+    if has_url is True:
+        stmt = stmt.where(Node.url.isnot(None))
+    elif has_url is False:
+        stmt = stmt.where(Node.url.is_(None))
+    if tags:
+        stmt = stmt.where(Node.tags.op("@>")(cast(tags, JSONB)))
+    if is_orphan is True:
+        stmt = stmt.where(Node.parent_node_id.is_(None))
+    elif is_orphan is False:
+        stmt = stmt.where(Node.parent_node_id.isnot(None))
     stmt = stmt.limit(limit).offset(offset)
     res = await db.execute(stmt)
     return list(res.scalars().all())

--- a/frontend/src/app/dashboard/nodes/page.tsx
+++ b/frontend/src/app/dashboard/nodes/page.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Plus, Search, Server, Pencil, Trash2, Tags, X, ChevronDown, ChevronRight } from "lucide-react";
 
 import { useAuth } from "@/lib/auth";
-import { api, type NodePublic } from "@/lib/api";
+import { api, type NodePublic, type NodeStats } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -13,6 +13,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { NodeDialog } from "@/components/node-dialog";
 import { NodeDetailDialog } from "@/components/node-detail-dialog";
 import { BulkTagDialog } from "@/components/bulk-tag-dialog";
+import { NodeFilters, type NodeFilterState, emptyFilters, countActiveFilters } from "@/components/node-filters";
 
 export default function NodesPage() {
   const { activeTeam } = useAuth();
@@ -29,25 +30,41 @@ export default function NodesPage() {
   const [bulkBusy, setBulkBusy] = useState(false);
   const [tagDialogMode, setTagDialogMode] = useState<"add" | "remove" | null>(null);
 
+  const [filters, setFilters] = useState<NodeFilterState>(emptyFilters);
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const [stats, setStats] = useState<NodeStats | null>(null);
+
   const load = useCallback(async () => {
     if (!activeTeam) return;
     setLoading(true);
     try {
-      const data = await api.nodes.list(activeTeam.id, { q: query || undefined, limit: 200 });
+      const data = await api.nodes.list(activeTeam.id, {
+        q: query || undefined,
+        limit: 200,
+        kind: filters.kinds.length > 0 ? filters.kinds : undefined,
+        has_url: filters.hasUrl ?? undefined,
+        tags: filters.tags.length > 0 ? filters.tags : undefined,
+        is_orphan: filters.isOrphan ?? undefined,
+      });
       setNodes(data);
     } catch {
       setNodes([]);
     } finally {
       setLoading(false);
     }
-  }, [activeTeam, query]);
+  }, [activeTeam, query, filters]);
 
   useEffect(() => { load(); }, [load]);
 
   useEffect(() => {
+    if (!activeTeam) return;
+    api.nodes.stats(activeTeam.id).then(setStats).catch(() => {});
+  }, [activeTeam]);
+
+  useEffect(() => {
     setSelectedIds(new Set());
     setExpandedIds(new Set());
-  }, [activeTeam, query]);
+  }, [activeTeam, query, filters]);
 
   const allSelected = nodes.length > 0 && selectedIds.size === nodes.length;
   const someSelected = selectedIds.size > 0;
@@ -226,6 +243,15 @@ export default function NodesPage() {
         />
       </div>
 
+      <NodeFilters
+        filters={filters}
+        onChange={setFilters}
+        open={filtersOpen}
+        onToggle={() => setFiltersOpen((v) => !v)}
+        availableTags={stats?.top_tags.map((t) => t.tag) ?? []}
+        availableKinds={stats ? Object.keys(stats.by_kind) : ["device", "site", "service", "other"]}
+      />
+
       <div className="flex flex-wrap items-center gap-2">
         <Button
           size="sm"
@@ -322,7 +348,7 @@ export default function NodesPage() {
           <CardContent className="py-16 text-center">
             <Server className="mx-auto h-10 w-10 text-[hsl(var(--muted-foreground))]" />
             <p className="mt-3 text-sm text-[hsl(var(--muted-foreground))]">
-              {query ? "No nodes match your search." : "No nodes yet. Click \"Add node\" to create one."}
+              {query || countActiveFilters(filters) > 0 ? "No nodes match your search or filters." : "No nodes yet. Click \"Add node\" to create one."}
             </p>
           </CardContent>
         </Card>

--- a/frontend/src/components/node-filters.tsx
+++ b/frontend/src/components/node-filters.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { Filter, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+
+export interface NodeFilterState {
+  kinds: string[];
+  hasUrl: boolean | null;
+  tags: string[];
+  isOrphan: boolean | null;
+}
+
+export const emptyFilters: NodeFilterState = { kinds: [], hasUrl: null, tags: [], isOrphan: null };
+
+export function countActiveFilters(f: NodeFilterState): number {
+  let n = 0;
+  if (f.kinds.length > 0) n++;
+  if (f.hasUrl !== null) n++;
+  if (f.tags.length > 0) n++;
+  if (f.isOrphan !== null) n++;
+  return n;
+}
+
+interface NodeFiltersProps {
+  filters: NodeFilterState;
+  onChange: (filters: NodeFilterState) => void;
+  open: boolean;
+  onToggle: () => void;
+  availableTags: string[];
+  availableKinds: string[];
+}
+
+const kindColors: Record<string, string> = {
+  device: "bg-blue-100 text-blue-800 border-blue-300 dark:bg-blue-900 dark:text-blue-300 dark:border-blue-700",
+  site: "bg-green-100 text-green-800 border-green-300 dark:bg-green-900 dark:text-green-300 dark:border-green-700",
+  service: "bg-purple-100 text-purple-800 border-purple-300 dark:bg-purple-900 dark:text-purple-300 dark:border-purple-700",
+  other: "bg-gray-100 text-gray-800 border-gray-300 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600",
+};
+
+const kindColorsActive: Record<string, string> = {
+  device: "bg-blue-600 text-white border-blue-600 dark:bg-blue-500 dark:border-blue-500",
+  site: "bg-green-600 text-white border-green-600 dark:bg-green-500 dark:border-green-500",
+  service: "bg-purple-600 text-white border-purple-600 dark:bg-purple-500 dark:border-purple-500",
+  other: "bg-gray-600 text-white border-gray-600 dark:bg-gray-500 dark:border-gray-500",
+};
+
+export function NodeFilters({ filters, onChange, open, onToggle, availableTags, availableKinds }: NodeFiltersProps) {
+  const activeCount = countActiveFilters(filters);
+
+  function toggleKind(kind: string) {
+    const kinds = filters.kinds.includes(kind)
+      ? filters.kinds.filter((k) => k !== kind)
+      : [...filters.kinds, kind];
+    onChange({ ...filters, kinds });
+  }
+
+  function setHasUrl(val: boolean | null) {
+    onChange({ ...filters, hasUrl: val });
+  }
+
+  function toggleTag(tag: string) {
+    const tags = filters.tags.includes(tag)
+      ? filters.tags.filter((t) => t !== tag)
+      : [...filters.tags, tag];
+    onChange({ ...filters, tags });
+  }
+
+  function setIsOrphan(val: boolean | null) {
+    onChange({ ...filters, isOrphan: val });
+  }
+
+  function clearAll() {
+    onChange(emptyFilters);
+  }
+
+  return (
+    <div className="space-y-3">
+      <Button
+        variant="outline"
+        size="sm"
+        className="gap-1.5"
+        onClick={onToggle}
+      >
+        <Filter className="h-3.5 w-3.5" />
+        Filters
+        {activeCount > 0 && (
+          <span className="ml-1 flex h-5 w-5 items-center justify-center rounded-full bg-[hsl(var(--primary))] text-[10px] font-bold text-[hsl(var(--primary-foreground))]">
+            {activeCount}
+          </span>
+        )}
+      </Button>
+
+      {open && (
+        <div className="rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-4 space-y-4">
+          {/* Kind filter */}
+          <div className="space-y-1.5">
+            <span className="text-xs font-medium text-[hsl(var(--muted-foreground))] uppercase tracking-wide">Kind</span>
+            <div className="flex flex-wrap gap-1.5">
+              {availableKinds.map((kind) => {
+                const active = filters.kinds.includes(kind);
+                return (
+                  <button
+                    key={kind}
+                    type="button"
+                    onClick={() => toggleKind(kind)}
+                    className={`inline-flex items-center rounded-md border px-2.5 py-1 text-xs font-medium transition-colors cursor-pointer ${active ? kindColorsActive[kind] ?? kindColorsActive.other : kindColors[kind] ?? kindColors.other}`}
+                  >
+                    {kind}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Has URL filter */}
+          <div className="space-y-1.5">
+            <span className="text-xs font-medium text-[hsl(var(--muted-foreground))] uppercase tracking-wide">URL</span>
+            <div className="flex gap-1.5">
+              {([
+                [null, "Any"],
+                [true, "Has URL"],
+                [false, "No URL"],
+              ] as [boolean | null, string][]).map(([val, label]) => (
+                <Button
+                  key={label}
+                  size="sm"
+                  variant={filters.hasUrl === val ? "default" : "outline"}
+                  onClick={() => setHasUrl(val)}
+                  className="h-7 text-xs"
+                >
+                  {label}
+                </Button>
+              ))}
+            </div>
+          </div>
+
+          {/* Tags filter */}
+          {availableTags.length > 0 && (
+            <div className="space-y-1.5">
+              <span className="text-xs font-medium text-[hsl(var(--muted-foreground))] uppercase tracking-wide">Tags</span>
+              <div className="flex flex-wrap gap-1.5">
+                {availableTags.map((tag) => {
+                  const active = filters.tags.includes(tag);
+                  return (
+                    <Badge
+                      key={tag}
+                      variant={active ? "default" : "outline"}
+                      className={`cursor-pointer select-none transition-colors ${active ? "" : "hover:bg-[hsl(var(--muted))]"}`}
+                      onClick={() => toggleTag(tag)}
+                    >
+                      {tag}
+                    </Badge>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Orphan filter */}
+          <div className="space-y-1.5">
+            <span className="text-xs font-medium text-[hsl(var(--muted-foreground))] uppercase tracking-wide">Hierarchy</span>
+            <div className="flex gap-1.5">
+              {([
+                [null, "Any"],
+                [true, "Root only"],
+                [false, "Has parent"],
+              ] as [boolean | null, string][]).map(([val, label]) => (
+                <Button
+                  key={label}
+                  size="sm"
+                  variant={filters.isOrphan === val ? "default" : "outline"}
+                  onClick={() => setIsOrphan(val)}
+                  className="h-7 text-xs"
+                >
+                  {label}
+                </Button>
+              ))}
+            </div>
+          </div>
+
+          {/* Clear all */}
+          {activeCount > 0 && (
+            <div className="pt-1 border-t border-[hsl(var(--border))]">
+              <Button variant="ghost" size="sm" onClick={clearAll} className="gap-1.5 h-7 text-xs">
+                <X className="h-3 w-3" />
+                Clear all filters
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -288,12 +288,16 @@ export const api = {
     stats(teamId: string) {
       return request<NodeStats>(`/api/teams/${teamId}/nodes/stats`);
     },
-    list(teamId: string, params?: { q?: string; parent_id?: string; limit?: number; offset?: number }) {
+    list(teamId: string, params?: { q?: string; parent_id?: string; limit?: number; offset?: number; kind?: string[]; has_url?: boolean; tags?: string[]; is_orphan?: boolean }) {
       const qs = new URLSearchParams();
       if (params?.q) qs.set("q", params.q);
       if (params?.parent_id) qs.set("parent_id", params.parent_id);
       if (params?.limit) qs.set("limit", String(params.limit));
       if (params?.offset) qs.set("offset", String(params.offset));
+      if (params?.kind?.length) for (const k of params.kind) qs.append("kind", k);
+      if (params?.has_url !== undefined && params.has_url !== null) qs.set("has_url", String(params.has_url));
+      if (params?.tags?.length) for (const t of params.tags) qs.append("tags", t);
+      if (params?.is_orphan !== undefined && params.is_orphan !== null) qs.set("is_orphan", String(params.is_orphan));
       const q = qs.toString();
       return request<NodePublic[]>(`/api/teams/${teamId}/nodes${q ? `?${q}` : ""}`);
     },


### PR DESCRIPTION
## Summary
- Adds server-side filter params (`kind`, `has_url`, `tags`, `is_orphan`) to the `GET /api/teams/{team_id}/nodes` endpoint
- New collapsible filter bar UI on the nodes page with kind pills, URL toggle, tag badges, and hierarchy filter
- Filters combine with existing text search using AND logic

## Test plan
- [ ] Toggle kind filters and verify only matching nodes appear
- [ ] Test has URL / no URL toggle
- [ ] Select tags and verify nodes with ALL selected tags are shown
- [ ] Test root only / has parent hierarchy filter
- [ ] Combine multiple filters + text search
- [ ] Switch between grouped/flat view with active filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)