### PR TITLE
Add Ansible inventory export

### DIFF
--- a/backend/app/api/routes/nodes.py
+++ b/backend/app/api/routes/nodes.py
@@ -144,6 +144,8 @@ async def nodes_export_ansible(
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     await require_role(db, user=user, team_id=team_id, min_role="viewer")
+    if kind is None:
+        kind = ["device"]
     nodes = await list_nodes(
         db, team_id=team_id, q=q, kind=kind, has_url=has_url,
         tags=tags, is_orphan=is_orphan, limit=10000, offset=0,

--- a/backend/app/api/routes/nodes.py
+++ b/backend/app/api/routes/nodes.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from fastapi.responses import JSONResponse
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_user
@@ -11,6 +13,7 @@ from app.db.session import get_db
 from app.models.node import Node
 from app.models.user import User
 from app.schemas.nodes import BulkActionResponse, BulkDeleteRequest, BulkTagRequest, NodeCreate, NodePublic, NodeStats, NodeUpdate
+from app.services.ansible_inventory import build_ansible_inventory
 from app.services.nodes import (
     bulk_delete_nodes,
     bulk_update_tags,
@@ -126,6 +129,41 @@ async def nodes_bulk_tag(
     )
     await db.commit()
     return BulkActionResponse(affected=affected)
+
+
+@router.get("/export/ansible")
+async def nodes_export_ansible(
+    team_id: uuid.UUID,
+    groups: list[str] = Query(default=["kind", "tag", "parent", "subnet"]),
+    q: str | None = None,
+    kind: list[str] | None = Query(default=None),
+    has_url: bool | None = Query(default=None),
+    tags: list[str] | None = Query(default=None),
+    is_orphan: bool | None = Query(default=None),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    await require_role(db, user=user, team_id=team_id, min_role="viewer")
+    nodes = await list_nodes(
+        db, team_id=team_id, q=q, kind=kind, has_url=has_url,
+        tags=tags, is_orphan=is_orphan, limit=10000, offset=0,
+    )
+
+    parent_names: dict[uuid.UUID, str] = {}
+    if "parent" in groups:
+        parent_ids = {n.parent_node_id for n in nodes if n.parent_node_id}
+        if parent_ids:
+            stmt = select(Node.id, Node.name).where(Node.id.in_(parent_ids))
+            res = await db.execute(stmt)
+            parent_names = {row[0]: row[1] for row in res.all()}
+
+    inventory = build_ansible_inventory(
+        nodes, parent_names=parent_names, group_strategies=set(groups),
+    )
+    return JSONResponse(
+        content=inventory,
+        headers={"Content-Disposition": 'attachment; filename="inventory.json"'},
+    )
 
 
 @router.get("/{node_id}", response_model=NodePublic)

--- a/backend/app/services/ansible_inventory.py
+++ b/backend/app/services/ansible_inventory.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from ipaddress import IPv4Address, ip_address
+
+from app.models.node import Node
+
+
+def sanitize_group_name(name: str) -> str:
+    s = re.sub(r"[^A-Za-z0-9_]", "_", name.lower())
+    s = re.sub(r"_+", "_", s).strip("_")
+    if not s:
+        return ""
+    if s[0].isdigit():
+        s = "_" + s
+    return s
+
+
+def _extract_subnet(ip_str: str) -> str | None:
+    raw = ip_str.split("/")[0]
+    try:
+        addr = ip_address(raw)
+    except ValueError:
+        return None
+    if not isinstance(addr, IPv4Address):
+        return None
+    parts = raw.split(".")
+    return f"subnet_{parts[0]}_{parts[1]}_{parts[2]}"
+
+
+def build_ansible_inventory(
+    nodes: list[Node],
+    *,
+    parent_names: dict[uuid.UUID, str],
+    group_strategies: set[str] | None = None,
+) -> dict:
+    if group_strategies is None:
+        group_strategies = {"kind", "tag", "parent", "subnet"}
+
+    groups: dict[str, list[str]] = {}
+    hostvars: dict[str, dict] = {}
+    seen_hostnames: dict[str, int] = {}
+    skipped = 0
+
+    for node in nodes:
+        ip = (node.ip or "").strip() or None
+        hostname = (node.hostname or "").strip() or None
+
+        if not ip and not hostname:
+            skipped += 1
+            continue
+
+        ansible_host = ip if ip else hostname
+        # Strip CIDR notation for ansible_host
+        if ansible_host and "/" in ansible_host:
+            ansible_host = ansible_host.split("/")[0]
+
+        inv_hostname = hostname if hostname else node.name
+
+        # Disambiguate collisions
+        if inv_hostname in seen_hostnames:
+            seen_hostnames[inv_hostname] += 1
+            inv_hostname = f"{inv_hostname}_{str(node.id)[:8]}"
+        else:
+            seen_hostnames[inv_hostname] = 1
+
+        hv: dict = {
+            "ansible_host": ansible_host,
+            "nodebyte_id": str(node.id),
+            "nodebyte_kind": node.kind,
+            "nodebyte_name": node.name,
+            "nodebyte_tags": list(node.tags or []),
+        }
+        if node.url:
+            hv["nodebyte_url"] = node.url
+        if node.notes:
+            hv["nodebyte_notes"] = node.notes
+
+        for k, v in (node.meta or {}).items():
+            if isinstance(v, (str, int, float, bool)):
+                hv[f"nodebyte_meta_{k}"] = v
+            else:
+                hv[f"nodebyte_meta_{k}"] = json.dumps(v)
+
+        hostvars[inv_hostname] = hv
+
+        # --- Grouping ---
+
+        if "kind" in group_strategies:
+            gname = f"kind_{sanitize_group_name(node.kind)}"
+            if gname:
+                groups.setdefault(gname, []).append(inv_hostname)
+
+        if "tag" in group_strategies:
+            for tag in (node.tags or []):
+                gname = sanitize_group_name(tag)
+                if gname:
+                    groups.setdefault(f"tag_{gname}", []).append(inv_hostname)
+
+        if "parent" in group_strategies:
+            if node.parent_node_id and node.parent_node_id in parent_names:
+                pname = sanitize_group_name(parent_names[node.parent_node_id])
+                if pname:
+                    groups.setdefault(f"parent_{pname}", []).append(inv_hostname)
+            else:
+                groups.setdefault("ungrouped", []).append(inv_hostname)
+
+        if "subnet" in group_strategies and ip:
+            sn = _extract_subnet(ip)
+            if sn:
+                groups.setdefault(sn, []).append(inv_hostname)
+
+    inventory: dict = {
+        "all": {
+            "children": sorted(groups.keys()),
+        },
+        "_meta": {
+            "hostvars": hostvars,
+        },
+    }
+
+    for gname, hosts in groups.items():
+        inventory[gname] = {"hosts": sorted(hosts)}
+
+    if skipped:
+        inventory["_nodebyte_skipped"] = skipped
+
+    return inventory

--- a/frontend/src/app/dashboard/nodes/page.tsx
+++ b/frontend/src/app/dashboard/nodes/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Plus, Search, Server, Pencil, Trash2, Tags, X, ChevronDown, ChevronRight } from "lucide-react";
+import { Plus, Search, Server, Pencil, Trash2, Tags, X, ChevronDown, ChevronRight, Download } from "lucide-react";
 
 import { useAuth } from "@/lib/auth";
 import { api, type NodePublic, type NodeStats } from "@/lib/api";
@@ -141,6 +141,26 @@ export default function NodesPage() {
     load();
   }
 
+  const [exporting, setExporting] = useState(false);
+
+  async function handleExportAnsible() {
+    if (!activeTeam) return;
+    setExporting(true);
+    try {
+      await api.nodes.exportAnsible(activeTeam.id, {
+        q: query || undefined,
+        kind: filters.kinds.length > 0 ? filters.kinds : undefined,
+        tags: filters.tags.length > 0 ? filters.tags : undefined,
+        is_orphan: filters.isOrphan ?? undefined,
+        has_url: filters.hasUrl ?? undefined,
+      });
+    } catch {
+      // silent — the download either works or the user sees no file
+    } finally {
+      setExporting(false);
+    }
+  }
+
   const kindColors: Record<string, string> = {
     device: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300",
     site: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300",
@@ -227,10 +247,22 @@ export default function NodesPage() {
     <div className="space-y-4">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <h1 className="text-2xl font-semibold tracking-tight">Nodes</h1>
-        <Button onClick={openCreate} size="sm" className="gap-1.5">
-          <Plus className="h-4 w-4" />
-          Add node
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button
+            onClick={handleExportAnsible}
+            size="sm"
+            variant="outline"
+            className="gap-1.5"
+            disabled={loading || nodes.length === 0 || exporting}
+          >
+            {exporting ? <Spinner className="h-4 w-4" /> : <Download className="h-4 w-4" />}
+            Export Ansible
+          </Button>
+          <Button onClick={openCreate} size="sm" className="gap-1.5">
+            <Plus className="h-4 w-4" />
+            Add node
+          </Button>
+        </div>
       </div>
 
       <div className="relative max-w-sm">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -325,6 +325,39 @@ export const api = {
         body: JSON.stringify({ node_ids: nodeIds, add: add ?? [], remove: remove ?? [] }),
       });
     },
+    async exportAnsible(teamId: string, params?: {
+      groups?: string[];
+      q?: string;
+      kind?: string[];
+      tags?: string[];
+      is_orphan?: boolean;
+      has_url?: boolean;
+    }): Promise<void> {
+      const qs = new URLSearchParams();
+      if (params?.groups?.length) for (const g of params.groups) qs.append("groups", g);
+      if (params?.q) qs.set("q", params.q);
+      if (params?.kind?.length) for (const k of params.kind) qs.append("kind", k);
+      if (params?.tags?.length) for (const t of params.tags) qs.append("tags", t);
+      if (params?.is_orphan !== undefined && params.is_orphan !== null) qs.set("is_orphan", String(params.is_orphan));
+      if (params?.has_url !== undefined && params.has_url !== null) qs.set("has_url", String(params.has_url));
+      const q = qs.toString();
+      const url = `${BASE}/api/teams/${teamId}/nodes/export/ansible${q ? `?${q}` : ""}`;
+      const headers: Record<string, string> = {};
+      if (accessToken) headers["Authorization"] = `Bearer ${accessToken}`;
+      const res = await fetch(url, { headers, credentials: "include" });
+      if (!res.ok) {
+        const body = await res.json();
+        throw new ApiError(res.status, body);
+      }
+      const blob = await res.blob();
+      const a = document.createElement("a");
+      a.href = URL.createObjectURL(blob);
+      a.download = "inventory.json";
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(a.href);
+    },
   },
   admin: {
     stats() {

--- a/scripts/ansible-inventory.py
+++ b/scripts/ansible-inventory.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Ansible dynamic inventory script for Nodebyte.
+
+Usage:
+  ansible -i ansible-inventory.py all -m ping
+  python3 ansible-inventory.py --list
+  python3 ansible-inventory.py --host <hostname>
+
+Environment variables:
+  NODEBYTE_URL        Base URL (e.g. https://nodebyte.example.com)
+  NODEBYTE_TEAM_ID    Team UUID to export
+
+  Auth (pick one):
+    NODEBYTE_TOKEN      Pre-existing JWT access token
+    NODEBYTE_EMAIL      Email for login
+    NODEBYTE_PASSWORD   Password for login
+
+  Optional:
+    NODEBYTE_GROUPS     Comma-separated grouping strategies (kind,tag,parent,subnet)
+    NODEBYTE_FILTER_KIND   Comma-separated kinds to include
+    NODEBYTE_FILTER_TAGS   Comma-separated tags to filter by
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+
+def _env(key, required=True):
+    val = os.environ.get(key, "").strip()
+    if required and not val:
+        sys.stderr.write(f"Error: {key} environment variable is required\n")
+        sys.exit(1)
+    return val or None
+
+
+def _api_request(url, token, data=None):
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    body = json.dumps(data).encode() if data else None
+    req = urllib.request.Request(url, data=body, headers=headers)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        sys.stderr.write(f"HTTP {e.code}: {e.read().decode()}\n")
+        sys.exit(1)
+
+
+def get_token():
+    token = _env("NODEBYTE_TOKEN", required=False)
+    if token:
+        return token
+    base = _env("NODEBYTE_URL")
+    email = _env("NODEBYTE_EMAIL")
+    password = _env("NODEBYTE_PASSWORD")
+    resp = _api_request(
+        f"{base}/api/auth/login",
+        token=None,
+        data={"email": email, "password": password},
+    )
+    return resp["access_token"]
+
+
+def fetch_inventory(token):
+    base = _env("NODEBYTE_URL")
+    team_id = _env("NODEBYTE_TEAM_ID")
+    params = []
+    groups = _env("NODEBYTE_GROUPS", required=False)
+    if groups:
+        for g in groups.split(","):
+            g = g.strip()
+            if g:
+                params.append(f"groups={urllib.request.quote(g)}")
+    kinds = _env("NODEBYTE_FILTER_KIND", required=False)
+    if kinds:
+        for k in kinds.split(","):
+            k = k.strip()
+            if k:
+                params.append(f"kind={urllib.request.quote(k)}")
+    tags = _env("NODEBYTE_FILTER_TAGS", required=False)
+    if tags:
+        for t in tags.split(","):
+            t = t.strip()
+            if t:
+                params.append(f"tags={urllib.request.quote(t)}")
+    qs = f"?{'&'.join(params)}" if params else ""
+    url = f"{base}/api/teams/{team_id}/nodes/export/ansible{qs}"
+    return _api_request(url, token)
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.stderr.write("Usage: ansible-inventory.py --list | --host <hostname>\n")
+        sys.exit(1)
+
+    token = get_token()
+
+    if sys.argv[1] == "--list":
+        inventory = fetch_inventory(token)
+        print(json.dumps(inventory, indent=2))
+
+    elif sys.argv[1] == "--host":
+        if len(sys.argv) < 3:
+            sys.stderr.write("Usage: ansible-inventory.py --host <hostname>\n")
+            sys.exit(1)
+        hostname = sys.argv[2]
+        inventory = fetch_inventory(token)
+        hostvars = inventory.get("_meta", {}).get("hostvars", {}).get(hostname, {})
+        print(json.dumps(hostvars, indent=2))
+
+    else:
+        sys.stderr.write(f"Unknown argument: {sys.argv[1]}\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add a `/api/teams/{team_id}/nodes/export/ansible` endpoint that generates Ansible-compatible JSON dynamic inventory from Nodebyte nodes
- Intelligent grouping by kind, tag, parent node, and /24 subnet — configurable via `groups` query param
- "Export Ansible" button on the Nodes dashboard that downloads `inventory.json`, respecting active search/filter state
- Standalone `scripts/ansible-inventory.py` dynamic inventory script for direct use with `ansible -i`

## Details

**Backend** (`backend/app/services/ansible_inventory.py`):
- Builds Ansible JSON inventory with `_meta.hostvars` for efficient single-call inventory
- Defaults to `kind=device` filter (most Ansible-relevant node type)
- Sanitizes group names to Ansible-safe identifiers
- Maps node metadata, tags, URL, and notes into host variables (prefixed `nodebyte_*`)
- Handles hostname collisions, CIDR stripping, and nodes without IP/hostname

**Frontend** (`frontend/src/app/dashboard/nodes/page.tsx`, `frontend/src/lib/api.ts`):
- Download button triggers blob download of the JSON inventory
- Passes current filters (search, kind, tags, orphan, has_url) through to the export

**Script** (`scripts/ansible-inventory.py`):
- Zero-dependency Python script implementing Ansible's `--list` / `--host` dynamic inventory interface
- Supports JWT token or email/password auth via environment variables
- Configurable grouping and filtering via `NODEBYTE_GROUPS`, `NODEBYTE_FILTER_KIND`, `NODEBYTE_FILTER_TAGS`

## Test plan

- [ ] Start app with `docker compose up`, create some device nodes with IPs and tags
- [ ] Click "Export Ansible" — verify `inventory.json` downloads with correct groups and hostvars
- [ ] Apply filters (kind, tag, search) then export — verify only matching nodes appear
- [ ] Run `ansible-inventory -i scripts/ansible-inventory.py --list` against a running instance
- [ ] Verify nodes without IP or hostname are skipped (counted in `_nodebyte_skipped`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)