### PR TITLE
Add rate limiting to /register-node

### DIFF
--- a/backend/app/api/routes/register_node.py
+++ b/backend/app/api/routes/register_node.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, Response
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.rate_limit import rate_limit_register_node
 from app.db.session import get_db
 from app.schemas.nodes import NodePublic
 from app.schemas.registration_tokens import NodeRegisterRequest
@@ -14,9 +15,11 @@ router = APIRouter(tags=["node-registration"])
 @router.post("/register-node", response_model=NodePublic, status_code=201)
 async def register_node(
     payload: NodeRegisterRequest,
+    request: Request,
     response: Response,
     db: AsyncSession = Depends(get_db),
 ):
+    rate_limit_register_node(request)
     rt = await get_registration_token_by_value(db, token=payload.token)
     if not rt:
         raise HTTPException(status_code=401, detail="Invalid registration token")

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -81,6 +81,11 @@ def rate_limit_register(request: Request) -> None:
     _limiter.check(f"register:{_client_ip(request)}", max_hits=5, window_seconds=3600)
 
 
+def rate_limit_register_node(request: Request) -> None:
+    ip = _client_ip(request)
+    _limiter.check(f"regnode-ip:{ip}", max_hits=30, window_seconds=60)
+
+
 def rate_limit_login(request: Request, payload: LoginRequest) -> None:
     """
     Login rate limiting.


### PR DESCRIPTION
## Summary

- Add per-IP rate limiting (30 req/min) to `POST /register-node` — previously the only unprotected write endpoint
- Reuses the existing in-memory sliding-window rate limiter and trusted-proxy IP detection

## Context

Hundreds of registration requests returning 200s were observed in production logs. The `/register-node` endpoint had no rate limiting (only token validation), so a misconfigured agent or leaked token could hammer it indefinitely. User registration and login already had rate limits; this was the gap.

## Changes

- `backend/app/core/rate_limit.py` — new `rate_limit_register_node()`: 30 hits per IP per 60s window
- `backend/app/api/routes/register_node.py` — call rate limiter before any DB work

## Test plan

- [ ] `POST /register-node` 30× rapidly — all succeed
- [ ] 31st request within 60s — returns 429 Too Many Requests
- [ ] Requests from a different IP are not affected
- [ ] Existing registration token validation still works (401/403 for bad/revoked/expired tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)