### PR TITLE
Add batch node registration endpoint

### DIFF
--- a/backend/app/api/routes/register_node.py
+++ b/backend/app/api/routes/register_node.py
@@ -5,10 +5,26 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_db
 from app.schemas.nodes import NodePublic
-from app.schemas.registration_tokens import NodeRegisterRequest
+from app.schemas.registration_tokens import (
+    BatchNodeRegisterRequest,
+    BatchNodeRegisterResponse,
+    BatchNodeResult,
+    NodeRegisterRequest,
+)
 from app.services.registration_tokens import get_registration_token_by_value, register_or_update_node_with_token
 
 router = APIRouter(tags=["node-registration"])
+
+
+async def _validate_token(db: AsyncSession, token: str):
+    rt = await get_registration_token_by_value(db, token=token)
+    if not rt:
+        raise HTTPException(status_code=401, detail="Invalid registration token")
+    if not rt.is_active:
+        raise HTTPException(status_code=403, detail="This registration token has been revoked")
+    if rt.is_expired:
+        raise HTTPException(status_code=403, detail="This registration token has expired")
+    return rt
 
 
 @router.post("/register-node", response_model=NodePublic, status_code=201)
@@ -17,15 +33,7 @@ async def register_node(
     response: Response,
     db: AsyncSession = Depends(get_db),
 ):
-    rt = await get_registration_token_by_value(db, token=payload.token)
-    if not rt:
-        raise HTTPException(status_code=401, detail="Invalid registration token")
-
-    # Revoked/expired tokens should never be usable, even for updates.
-    if not rt.is_active:
-        raise HTTPException(status_code=403, detail="This registration token has been revoked")
-    if rt.is_expired:
-        raise HTTPException(status_code=403, detail="This registration token has expired")
+    rt = await _validate_token(db, payload.token)
 
     if rt.allowed_kinds and payload.kind not in rt.allowed_kinds:
         raise HTTPException(
@@ -43,6 +51,67 @@ async def register_node(
         response.status_code = 200
 
     await db.commit()
-    # Ensure any DB-generated fields are loaded before Pydantic serialization.
     await db.refresh(node)
     return node
+
+
+@router.post("/register-nodes", response_model=BatchNodeRegisterResponse)
+async def register_nodes_batch(
+    payload: BatchNodeRegisterRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    rt = await _validate_token(db, payload.token)
+
+    created = 0
+    updated = 0
+    skipped = 0
+    errors = 0
+    results: list[BatchNodeResult] = []
+
+    for item in payload.nodes:
+        if rt.allowed_kinds and item.kind not in rt.allowed_kinds:
+            errors += 1
+            results.append(BatchNodeResult(
+                name=item.name, hostname=item.hostname, status="error",
+                detail=f"Kind '{item.kind}' not allowed by this token",
+            ))
+            continue
+
+        data = item.model_dump()
+        allow_create = not rt.is_exhausted
+        try:
+            node, was_created = await register_or_update_node_with_token(
+                db, rt=rt, data=data, allow_create=allow_create,
+            )
+        except Exception as exc:
+            errors += 1
+            results.append(BatchNodeResult(
+                name=item.name, hostname=item.hostname, status="error",
+                detail=str(exc),
+            ))
+            continue
+
+        if node is None:
+            skipped += 1
+            results.append(BatchNodeResult(
+                name=item.name, hostname=item.hostname, status="skipped",
+                detail="Token has reached its usage limit",
+            ))
+            continue
+
+        if was_created:
+            created += 1
+        else:
+            updated += 1
+        results.append(BatchNodeResult(
+            name=item.name, hostname=item.hostname,
+            status="created" if was_created else "updated",
+            node_id=node.id,
+        ))
+
+    await db.commit()
+
+    return BatchNodeRegisterResponse(
+        created=created, updated=updated, skipped=skipped, errors=errors,
+        results=results,
+    )

--- a/backend/app/schemas/registration_tokens.py
+++ b/backend/app/schemas/registration_tokens.py
@@ -40,3 +40,38 @@ class NodeRegisterRequest(BaseModel):
     tags: list[str] = Field(default_factory=list)
     meta: dict = Field(default_factory=dict)
     notes: str | None = None
+
+
+class NodeRegisterItem(BaseModel):
+    """Single node within a batch registration request."""
+    name: str = Field(min_length=1, max_length=200)
+    kind: str = Field(default="device", max_length=30)
+    hostname: str | None = Field(default=None, max_length=255)
+    parent_hostname: str | None = Field(default=None, max_length=255)
+    ip: str | None = Field(default=None, max_length=64)
+    url: str | None = Field(default=None, max_length=2048)
+    tags: list[str] = Field(default_factory=list)
+    meta: dict = Field(default_factory=dict)
+    notes: str | None = None
+
+
+class BatchNodeRegisterRequest(BaseModel):
+    """Batch registration: one token, many nodes."""
+    token: str
+    nodes: list[NodeRegisterItem] = Field(min_length=1, max_length=1000)
+
+
+class BatchNodeResult(BaseModel):
+    name: str
+    hostname: str | None
+    status: str  # "created", "updated", "skipped", "error"
+    node_id: uuid.UUID | None = None
+    detail: str | None = None
+
+
+class BatchNodeRegisterResponse(BaseModel):
+    created: int
+    updated: int
+    skipped: int
+    errors: int
+    results: list[BatchNodeResult]

--- a/scripts/docker-inventory.sh
+++ b/scripts/docker-inventory.sh
@@ -18,17 +18,21 @@
 
 set -euo pipefail
 
-API="${NODEBYTE_URL:?Set NODEBYTE_URL (e.g. https://nodebyte.example.com)}/api/register-node"
+BASE_URL="${NODEBYTE_URL:?Set NODEBYTE_URL (e.g. https://nodebyte.example.com)}"
+API="${BASE_URL}/api/register-node"
+BATCH_API="${BASE_URL}/api/register-nodes"
 TOKEN="${NODEBYTE_TOKEN:?Set NODEBYTE_TOKEN before running this script}"
 KIND="${NODEBYTE_KIND:-device}"
 EXTRA_TAGS="${NODEBYTE_TAGS:-}"
 DOCKER_ALL="${DOCKER_ALL:-1}"
+NODEBYTE_BATCH="${NODEBYTE_BATCH:-1}"
 
 MAX_NAME_LEN=200
 MAX_HOSTNAME_LEN=255
 
+BATCH_ITEMS='[]'
+
 json_error_summary() {
-  # Best-effort: print "detail" field if it's JSON.
   local body="$1"
   if echo "$body" | jq -e . >/dev/null 2>&1; then
     echo "$body" | jq -r 'if .detail then .detail else . end | tostring'
@@ -146,8 +150,7 @@ for row in $(echo "$INSPECT" | jq -r '.[] | @base64'); do
     HOSTNAME_VAL="${HOSTNAME_VAL:0:MAX_HOSTNAME_LEN}"
   fi
 
-  PAYLOAD="$(jq -n \
-    --arg token "$TOKEN" \
+  NODE_JSON="$(jq -n \
     --arg name "$NAME" \
     --arg kind "$KIND" \
     --arg hostname "$HOSTNAME_VAL" \
@@ -156,7 +159,6 @@ for row in $(echo "$INSPECT" | jq -r '.[] | @base64'); do
     --argjson tags "$TAGS" \
     --argjson meta "$META" \
     '{
-      token: $token,
       name: $name,
       kind: $kind,
       hostname: $hostname,
@@ -168,224 +170,69 @@ for row in $(echo "$INSPECT" | jq -r '.[] | @base64'); do
     | if .parent_hostname == "" then del(.parent_hostname) else . end'
   )"
 
-  printf "  %-28s %-10s %-16s " "$NAME" "$STATUS" "${IP:-—}"
-
-  RESP="$(curl -sS -X POST "$API" \
-    -H "Content-Type: application/json" \
-    -d "$PAYLOAD" \
-    -w '\n%{http_code}')"
-
-  BODY="${RESP%$'\n'*}"
-  HTTP_CODE="${RESP##*$'\n'}"
-
-  if [[ "$HTTP_CODE" == "201" ]]; then
-    echo "✓ registered"
-    OK=$((OK + 1))
-  elif [[ "$HTTP_CODE" == "200" ]]; then
-    echo "↻ updated"
-    OK=$((OK + 1))
+  if [[ "$NODEBYTE_BATCH" == "1" ]]; then
+    BATCH_ITEMS="$(echo "$BATCH_ITEMS" | jq --argjson item "$NODE_JSON" '. + [$item]')"
+    printf "  %-28s %-10s %-16s queued\n" "$NAME" "$STATUS" "${IP:-—}"
   else
-    MSG="$(json_error_summary "$BODY")"
-    MSG_ONELINE="$(echo "$MSG" | tr '\n' ' ' | cut -c1-220)"
-    echo "✗ failed (HTTP $HTTP_CODE) $MSG_ONELINE"
-    FAIL=$((FAIL + 1))
+    PAYLOAD="$(echo "$NODE_JSON" | jq --arg token "$TOKEN" '. + {token: $token}')"
+
+    printf "  %-28s %-10s %-16s " "$NAME" "$STATUS" "${IP:-—}"
+
+    RESP="$(curl -sS -X POST "$API" \
+      -H "Content-Type: application/json" \
+      -d "$PAYLOAD" \
+      -w '\n%{http_code}')"
+
+    BODY="${RESP%$'\n'*}"
+    HTTP_CODE="${RESP##*$'\n'}"
+
+    if [[ "$HTTP_CODE" == "201" ]]; then
+      echo "✓ registered"
+      OK=$((OK + 1))
+    elif [[ "$HTTP_CODE" == "200" ]]; then
+      echo "↻ updated"
+      OK=$((OK + 1))
+    else
+      MSG="$(json_error_summary "$BODY")"
+      MSG_ONELINE="$(echo "$MSG" | tr '\n' ' ' | cut -c1-220)"
+      echo "✗ failed (HTTP $HTTP_CODE) $MSG_ONELINE"
+      FAIL=$((FAIL + 1))
+    fi
   fi
 done
 
-echo ""
-echo "Done. $OK ok, $FAIL failed (out of $COUNT)."
+if [[ "$NODEBYTE_BATCH" == "1" ]]; then
+  BATCH_COUNT="$(echo "$BATCH_ITEMS" | jq 'length')"
+  if [[ "$BATCH_COUNT" != "0" ]]; then
+    echo ""
+    echo "Sending batch of $BATCH_COUNT nodes..."
 
-#!/usr/bin/env bash
-# Nodebyte Docker inventory — register all containers from a Docker host
-#
-# Usage:
-#   NODEBYTE_TOKEN="your-registration-token" \
-#   NODEBYTE_URL="https://your-nodebyte-instance" \
-#     bash docker-inventory.sh
-#
-# Optional:
-#   NODEBYTE_KIND     — node kind to register as (default: "device")
-#   NODEBYTE_TAGS     — comma-separated extra tags (default: none)
-#   DOCKER_ALL        — set to "0" to register only running containers (default: 1)
-#
-# Notes:
-# - Requires: docker, jq, curl
-# - Re-running is safe: backend /api/register-node is idempotent (updates by hostname).
+    PAYLOAD="$(jq -n --arg token "$TOKEN" --argjson nodes "$BATCH_ITEMS" \
+      '{token: $token, nodes: $nodes}')"
 
-set -euo pipefail
+    RESP="$(curl -sS -X POST "$BATCH_API" \
+      -H "Content-Type: application/json" \
+      -d "$PAYLOAD" \
+      -w '\n%{http_code}')"
 
-API="${NODEBYTE_URL:?Set NODEBYTE_URL (e.g. https://nodebyte.example.com)}/api/register-node"
-TOKEN="${NODEBYTE_TOKEN:?Set NODEBYTE_TOKEN before running this script}"
-KIND="${NODEBYTE_KIND:-device}"
-EXTRA_TAGS="${NODEBYTE_TAGS:-}"
-DOCKER_ALL="${DOCKER_ALL:-1}"
+    BODY="${RESP%$'\n'*}"
+    HTTP_CODE="${RESP##*$'\n'}"
 
-MAX_NAME_LEN=200
-MAX_HOSTNAME_LEN=255
-
-json_error_summary() {
-  # Best-effort: print "detail" field if it's JSON.
-  local body="$1"
-  if echo "$body" | jq -e . >/dev/null 2>&1; then
-    echo "$body" | jq -r 'if .detail then .detail else . end | tostring'
-  else
-    echo "$body"
+    if [[ "$HTTP_CODE" == "200" ]]; then
+      local_created="$(echo "$BODY" | jq '.created')"
+      local_updated="$(echo "$BODY" | jq '.updated')"
+      local_skipped="$(echo "$BODY" | jq '.skipped')"
+      local_errors="$(echo "$BODY" | jq '.errors')"
+      OK=$((local_created + local_updated))
+      FAIL=$((local_skipped + local_errors))
+      echo "  ✓ $local_created created, $local_updated updated, $local_skipped skipped, $local_errors errors"
+    else
+      MSG="$(json_error_summary "$BODY")"
+      echo "  ✗ Batch failed (HTTP $HTTP_CODE): $MSG"
+      FAIL=$COUNT
+    fi
   fi
-}
-
-for cmd in docker jq curl; do
-  command -v "$cmd" >/dev/null 2>&1 || { echo "Error: $cmd is required but not installed." >&2; exit 1; }
-done
-
-HOST="$(hostname)"
-HOST_FQDN="$(hostname -f 2>/dev/null || hostname)"
-
-PS_ARGS=(-q)
-if [[ "$DOCKER_ALL" == "1" ]]; then
-  PS_ARGS+=(-a)
 fi
-
-IDS="$(docker ps "${PS_ARGS[@]}" 2>/dev/null || true)"
-if [[ -z "${IDS//[[:space:]]/}" ]]; then
-  echo "No containers found."
-  exit 0
-fi
-
-echo "Inspecting containers..."
-INSPECT="$(docker inspect $IDS)"
-COUNT="$(echo "$INSPECT" | jq 'length')"
-
-echo "Found $COUNT container(s). Registering with Nodebyte..."
-echo ""
-
-OK=0
-FAIL=0
-
-for row in $(echo "$INSPECT" | jq -r '.[] | @base64'); do
-  _jq() { echo "$row" | base64 -d | jq -r "${1}"; }
-
-  NAME_RAW="$(_jq '.Name | ltrimstr("/")')"
-  NAME="$NAME_RAW"
-  CID="$(_jq '.Id')"
-  CID_SHORT="$(echo "$CID" | cut -c1-12)"
-  IMAGE="$(_jq '.Config.Image // ""')"
-  STATUS="$(_jq '.State.Status // "unknown"')"
-  CREATED="$(_jq '.Created // ""')"
-
-  IPS_JSON="$(echo "$row" | base64 -d | jq -c '
-    [
-      (.NetworkSettings.Networks // {} | to_entries[]? as $net
-        | ($net.value.IPAddress // "") as $v4
-        | ($net.value.GlobalIPv6Address // "") as $v6
-        | (if ($v4 | length) > 0 then { network: $net.key, family: "inet", scope: "container", address: $v4 } else empty end),
-          (if ($v6 | length) > 0 then { network: $net.key, family: "inet6", scope: "container", address: $v6 } else empty end)
-      )
-    ]'
-  )"
-
-  IP="$(echo "$IPS_JSON" | jq -r '
-    (map(select(.family == "inet") | .address) | first) // ""
-  ')"
-
-  PORTS_JSON="$(echo "$row" | base64 -d | jq -c '(.NetworkSettings.Ports // {})')"
-  LABELS_JSON="$(echo "$row" | base64 -d | jq -c '(.Config.Labels // {})')"
-
-  TAGS='["docker","container"]'
-  TAGS="$(echo "$TAGS" | jq --arg s "$STATUS" '. + [($s | ascii_downcase)]')"
-  if [[ -n "$EXTRA_TAGS" ]]; then
-    IFS=',' read -ra ETAGS <<< "$EXTRA_TAGS"
-    for t in "${ETAGS[@]}"; do
-      t="$(echo "$t" | xargs)"
-      [[ -n "$t" ]] && TAGS="$(echo "$TAGS" | jq --arg t "$t" '. + [$t]')"
-    done
-  fi
-
-  META="$(jq -n \
-    --arg docker_host "$HOST" \
-    --arg container_id "$CID" \
-    --arg container_id_short "$CID_SHORT" \
-    --arg container_name "$NAME_RAW" \
-    --arg image "$IMAGE" \
-    --arg status "$STATUS" \
-    --arg created "$CREATED" \
-    --argjson ips "$IPS_JSON" \
-    --argjson ports "$PORTS_JSON" \
-    --argjson labels "$LABELS_JSON" \
-    '{
-      docker_host: $docker_host,
-      container_id: $container_id,
-      container_id_short: $container_id_short,
-      container_name: $container_name,
-      image: $image,
-      status: $status,
-      created: $created,
-      ips: $ips,
-      ports: $ports,
-      labels: $labels
-    }'
-  )"
-
-  # Enforce backend constraints:
-  # - name max 200 chars
-  # - hostname max 255 chars
-  if (( ${#NAME} > MAX_NAME_LEN )); then
-    NAME="${NAME:0:MAX_NAME_LEN}"
-  fi
-
-  HOSTNAME_VAL="${NAME_RAW}.${HOST_FQDN}"
-  if (( ${#HOSTNAME_VAL} > MAX_HOSTNAME_LEN )); then
-    HOSTNAME_VAL="${CID_SHORT}.${HOST_FQDN}"
-  fi
-  if (( ${#HOSTNAME_VAL} > MAX_HOSTNAME_LEN )); then
-    HOSTNAME_VAL="${CID_SHORT}.${HOST}"
-  fi
-  if (( ${#HOSTNAME_VAL} > MAX_HOSTNAME_LEN )); then
-    HOSTNAME_VAL="${HOSTNAME_VAL:0:MAX_HOSTNAME_LEN}"
-  fi
-
-  PAYLOAD="$(jq -n \
-    --arg token "$TOKEN" \
-    --arg name "$NAME" \
-    --arg kind "$KIND" \
-    --arg hostname "$HOSTNAME_VAL" \
-    --arg ip "$IP" \
-    --argjson tags "$TAGS" \
-    --argjson meta "$META" \
-    '{
-      token: $token,
-      name: $name,
-      kind: $kind,
-      hostname: $hostname,
-      tags: $tags,
-      meta: $meta
-    }
-    | if .ip == "" then del(.ip) else . end'
-  )"
-
-  printf "  %-28s %-10s %-16s " "$NAME" "$STATUS" "${IP:-—}"
-
-  RESP="$(curl -sS -X POST "$API" \
-    -H "Content-Type: application/json" \
-    -d "$PAYLOAD" \
-    -w '\n%{http_code}')"
-
-  BODY="${RESP%$'\n'*}"
-  HTTP_CODE="${RESP##*$'\n'}"
-
-  if [[ "$HTTP_CODE" == "201" ]]; then
-    echo "✓ registered"
-    OK=$((OK + 1))
-  elif [[ "$HTTP_CODE" == "200" ]]; then
-    echo "↻ updated"
-    OK=$((OK + 1))
-  else
-    MSG="$(json_error_summary "$BODY")"
-    # keep output readable
-    MSG_ONELINE="$(echo "$MSG" | tr '\n' ' ' | cut -c1-220)"
-    echo "✗ failed (HTTP $HTTP_CODE) $MSG_ONELINE"
-    FAIL=$((FAIL + 1))
-  fi
-done
 
 echo ""
 echo "Done. $OK ok, $FAIL failed (out of $COUNT)."

--- a/scripts/kubernetes-inventory.sh
+++ b/scripts/kubernetes-inventory.sh
@@ -24,9 +24,12 @@
 
 set -euo pipefail
 
-API="${NODEBYTE_URL:?Set NODEBYTE_URL (e.g. https://nodebyte.example.com)}/api/register-node"
+BASE_URL="${NODEBYTE_URL:?Set NODEBYTE_URL (e.g. https://nodebyte.example.com)}"
+API="${BASE_URL}/api/register-node"
+BATCH_API="${BASE_URL}/api/register-nodes"
 TOKEN="${NODEBYTE_TOKEN:?Set NODEBYTE_TOKEN before running this script}"
 EXTRA_TAGS="${NODEBYTE_TAGS:-}"
+NODEBYTE_BATCH="${NODEBYTE_BATCH:-1}"
 K8S_SKIP_SYSTEM="${K8S_SKIP_SYSTEM:-0}"
 K8S_NAMESPACES="${K8S_NAMESPACES:-}"
 K8S_RESOURCES="${K8S_RESOURCES:-nodes,namespaces,deployments,statefulsets,daemonsets,services,ingresses}"
@@ -39,6 +42,7 @@ MAX_HOSTNAME_LEN=255
 OK=0
 FAIL=0
 TOTAL=0
+BATCH_ITEMS='[]'
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -76,15 +80,11 @@ truncate_field() {
   fi
 }
 
-register_node() {
-  # Usage: register_node <name> <kind> <hostname> <parent_hostname> <ip> <url> <tags_json> <meta_json>
+_build_node_json() {
   local name="$1" kind="$2" hostname="$3" parent_hostname="$4" ip="$5" url="$6" tags="$7" meta="$8"
-
   name="$(truncate_field "$name" "$MAX_NAME_LEN")"
   hostname="$(truncate_field "$hostname" "$MAX_HOSTNAME_LEN")"
-
-  PAYLOAD="$(jq -n \
-    --arg token "$TOKEN" \
+  jq -n \
     --arg name "$name" \
     --arg kind "$kind" \
     --arg hostname "$hostname" \
@@ -94,7 +94,6 @@ register_node() {
     --argjson tags "$tags" \
     --argjson meta "$meta" \
     '{
-      token: $token,
       name: $name,
       kind: $kind,
       hostname: $hostname,
@@ -107,9 +106,24 @@ register_node() {
     | if .ip == "" then del(.ip) else . end
     | if .url == "" then del(.url) else . end
     | if .parent_hostname == "" then del(.parent_hostname) else . end'
-  )"
+}
+
+register_node() {
+  # Usage: register_node <name> <kind> <hostname> <parent_hostname> <ip> <url> <tags_json> <meta_json>
+  local name="$1" kind="$2" hostname="$3" parent_hostname="$4" ip="$5" url="$6" tags="$7" meta="$8"
 
   TOTAL=$((TOTAL + 1))
+
+  local NODE_JSON
+  NODE_JSON="$(_build_node_json "$name" "$kind" "$hostname" "$parent_hostname" "$ip" "$url" "$tags" "$meta")"
+
+  if [[ "$NODEBYTE_BATCH" == "1" ]]; then
+    BATCH_ITEMS="$(echo "$BATCH_ITEMS" | jq --argjson item "$NODE_JSON" '. + [$item]')"
+    printf "  %-40s %-12s queued\n" "$name" "$kind"
+    return
+  fi
+
+  PAYLOAD="$(echo "$NODE_JSON" | jq --arg token "$TOKEN" '. + {token: $token}')"
 
   printf "  %-40s %-12s " "$name" "$kind"
 
@@ -133,6 +147,45 @@ register_node() {
     echo "✗ failed (HTTP $HTTP_CODE) $MSG_ONELINE"
     FAIL=$((FAIL + 1))
   fi
+}
+
+flush_batch() {
+  local count
+  count="$(echo "$BATCH_ITEMS" | jq 'length')"
+  if [[ "$count" == "0" ]]; then
+    return
+  fi
+
+  echo ""
+  echo "Sending batch of $count nodes..."
+
+  PAYLOAD="$(jq -n --arg token "$TOKEN" --argjson nodes "$BATCH_ITEMS" \
+    '{token: $token, nodes: $nodes}')"
+
+  RESP="$(curl -sS -X POST "$BATCH_API" \
+    -H "Content-Type: application/json" \
+    -d "$PAYLOAD" \
+    -w '\n%{http_code}')"
+
+  BODY="${RESP%$'\n'*}"
+  HTTP_CODE="${RESP##*$'\n'}"
+
+  if [[ "$HTTP_CODE" == "200" ]]; then
+    local created updated skipped errors
+    created="$(echo "$BODY" | jq '.created')"
+    updated="$(echo "$BODY" | jq '.updated')"
+    skipped="$(echo "$BODY" | jq '.skipped')"
+    errors="$(echo "$BODY" | jq '.errors')"
+    OK=$((created + updated))
+    FAIL=$((skipped + errors))
+    echo "  ✓ $created created, $updated updated, $skipped skipped, $errors errors"
+  else
+    MSG="$(json_error_summary "$BODY")"
+    echo "  ✗ Batch failed (HTTP $HTTP_CODE): $MSG"
+    FAIL=$TOTAL
+  fi
+
+  BATCH_ITEMS='[]'
 }
 
 should_collect() {
@@ -632,6 +685,12 @@ if should_collect "ingresses"; then
     done
   done
   echo ""
+fi
+
+# ── Flush batch ─────────────────────────────────────────────────────────────
+
+if [[ "$NODEBYTE_BATCH" == "1" ]]; then
+  flush_batch
 fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────

--- a/scripts/lxd-inventory.sh
+++ b/scripts/lxd-inventory.sh
@@ -14,11 +14,15 @@
 
 set -euo pipefail
 
-API="${NODEBYTE_URL:?Set NODEBYTE_URL (e.g. https://nodebyte.example.com)}/api/register-node"
+BASE_URL="${NODEBYTE_URL:?Set NODEBYTE_URL (e.g. https://nodebyte.example.com)}"
+API="${BASE_URL}/api/register-node"
+BATCH_API="${BASE_URL}/api/register-nodes"
 TOKEN="${NODEBYTE_TOKEN:?Set NODEBYTE_TOKEN before running this script}"
 KIND="${NODEBYTE_KIND:-device}"
 EXTRA_TAGS="${NODEBYTE_TAGS:-}"
 REMOTE="${LXC_REMOTE:-}"
+NODEBYTE_BATCH="${NODEBYTE_BATCH:-1}"
+BATCH_ITEMS='[]'
 
 for cmd in lxc jq curl; do
   command -v "$cmd" >/dev/null 2>&1 || { echo "Error: $cmd is required but not installed." >&2; exit 1; }
@@ -108,8 +112,7 @@ for row in $(echo "$INSTANCES" | jq -r '.[] | @base64'); do
 
   HOSTNAME_VAL="${NAME}.${LXD_HOST_FQDN}"
 
-  PAYLOAD="$(jq -n \
-    --arg token "$TOKEN" \
+  NODE_JSON="$(jq -n \
     --arg name "$NAME" \
     --arg kind "$KIND" \
     --arg hostname "$HOSTNAME_VAL" \
@@ -118,7 +121,6 @@ for row in $(echo "$INSTANCES" | jq -r '.[] | @base64'); do
     --argjson tags "$TAGS" \
     --argjson meta "$META" \
     '{
-      token: $token,
       name: $name,
       kind: $kind,
       hostname: $hostname,
@@ -130,23 +132,63 @@ for row in $(echo "$INSTANCES" | jq -r '.[] | @base64'); do
     | if .parent_hostname == "" then del(.parent_hostname) else . end'
   )"
 
-  printf "  %-30s %-12s %-8s %-16s " "$NAME" "$TYPE" "$STATUS" "${IP:-—}"
-
-  HTTP_CODE="$(curl -s -o /dev/null -w '%{http_code}' -X POST "$API" \
-    -H "Content-Type: application/json" \
-    -d "$PAYLOAD")"
-
-  if [[ "$HTTP_CODE" == "201" ]]; then
-    echo "✓ registered"
-    OK=$((OK + 1))
-  elif [[ "$HTTP_CODE" == "200" ]]; then
-    echo "↻ updated"
-    OK=$((OK + 1))
+  if [[ "$NODEBYTE_BATCH" == "1" ]]; then
+    BATCH_ITEMS="$(echo "$BATCH_ITEMS" | jq --argjson item "$NODE_JSON" '. + [$item]')"
+    printf "  %-30s %-12s %-8s %-16s queued\n" "$NAME" "$TYPE" "$STATUS" "${IP:-—}"
   else
-    echo "✗ failed (HTTP $HTTP_CODE)"
-    FAIL=$((FAIL + 1))
+    PAYLOAD="$(echo "$NODE_JSON" | jq --arg token "$TOKEN" '. + {token: $token}')"
+
+    printf "  %-30s %-12s %-8s %-16s " "$NAME" "$TYPE" "$STATUS" "${IP:-—}"
+
+    HTTP_CODE="$(curl -s -o /dev/null -w '%{http_code}' -X POST "$API" \
+      -H "Content-Type: application/json" \
+      -d "$PAYLOAD")"
+
+    if [[ "$HTTP_CODE" == "201" ]]; then
+      echo "✓ registered"
+      OK=$((OK + 1))
+    elif [[ "$HTTP_CODE" == "200" ]]; then
+      echo "↻ updated"
+      OK=$((OK + 1))
+    else
+      echo "✗ failed (HTTP $HTTP_CODE)"
+      FAIL=$((FAIL + 1))
+    fi
   fi
 done
 
+if [[ "$NODEBYTE_BATCH" == "1" ]]; then
+  BATCH_COUNT="$(echo "$BATCH_ITEMS" | jq 'length')"
+  if [[ "$BATCH_COUNT" != "0" ]]; then
+    echo ""
+    echo "Sending batch of $BATCH_COUNT nodes..."
+
+    PAYLOAD="$(jq -n --arg token "$TOKEN" --argjson nodes "$BATCH_ITEMS" \
+      '{token: $token, nodes: $nodes}')"
+
+    RESP="$(curl -sS -X POST "$BATCH_API" \
+      -H "Content-Type: application/json" \
+      -d "$PAYLOAD" \
+      -w '\n%{http_code}')"
+
+    BODY="${RESP%$'\n'*}"
+    HTTP_CODE="${RESP##*$'\n'}"
+
+    if [[ "$HTTP_CODE" == "200" ]]; then
+      batch_created="$(echo "$BODY" | jq '.created')"
+      batch_updated="$(echo "$BODY" | jq '.updated')"
+      batch_skipped="$(echo "$BODY" | jq '.skipped')"
+      batch_errors="$(echo "$BODY" | jq '.errors')"
+      OK=$((batch_created + batch_updated))
+      FAIL=$((batch_skipped + batch_errors))
+      echo "  ✓ $batch_created created, $batch_updated updated, $batch_skipped skipped, $batch_errors errors"
+    else
+      MSG="$(echo "$BODY" | jq -r '.detail // .' 2>/dev/null || echo "$BODY")"
+      echo "  ✗ Batch failed (HTTP $HTTP_CODE): $MSG"
+      FAIL=$COUNT
+    fi
+  fi
+fi
+
 echo ""
-echo "Done. $OK registered, $FAIL failed (out of $COUNT)."
+echo "Done. $OK ok, $FAIL failed (out of $COUNT)."


### PR DESCRIPTION
## Summary

- New `POST /api/register-nodes` endpoint — accepts one token + up to 1000 nodes in a single request, returns per-node results
- All three inventory scripts (kubernetes, docker, lxd) now default to batch mode (`NODEBYTE_BATCH=1`)
- Removes duplicate script block from `docker-inventory.sh`

## Context

The K8s inventory script was making ~346 individual `POST /register-node` calls every hour (47,027 requests over 27 days, all 200 updates). Batch registration reduces that to 1 request per cycle.

## API

```json
POST /api/register-nodes
{
  "token": "...",
  "nodes": [
    {"name": "web-1", "kind": "device", "hostname": "web-1.example.com", "ip": "10.0.0.1", "tags": ["k8s"]},
    {"name": "web-2", "kind": "device", "hostname": "web-2.example.com", "ip": "10.0.0.2", "tags": ["k8s"]}
  ]
}

Response:
{
  "created": 0,
  "updated": 2,
  "skipped": 0,
  "errors": 0,
  "results": [
    {"name": "web-1", "hostname": "web-1.example.com", "status": "updated", "node_id": "..."},
    {"name": "web-2", "hostname": "web-2.example.com", "status": "updated", "node_id": "..."}
  ]
}
```

## Scripts

All scripts support `NODEBYTE_BATCH=0` to fall back to per-node requests (e.g., if targeting an older backend).

## Test plan

- [ ] `POST /api/register-nodes` with valid token and 5 new nodes → 5 created
- [ ] Re-send same batch → 5 updated, 0 created
- [ ] Include a node with a kind not in `allowed_kinds` → that node errors, others succeed
- [ ] Use an exhausted token → new nodes skipped, existing nodes updated
- [ ] `NODEBYTE_BATCH=1 bash kubernetes-inventory.sh` → single batch request in logs
- [ ] `NODEBYTE_BATCH=0 bash kubernetes-inventory.sh` → individual requests (fallback)
- [ ] Verify `POST /api/register-node` (singular) still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)