### PR TITLE
Add MCP server for programmatic node management

### DIFF
--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY server.py .
+
+ENV PORT=8080
+EXPOSE 8080
+
+USER 1000:1000
+
+CMD ["python", "server.py"]

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,64 @@
+# nodebyte-mcp
+
+A [Model Context Protocol](https://modelcontextprotocol.io) server for
+[Nodebyte](../README.md). It lets an MCP client (e.g. Claude) add, upload, and
+search nodes in a Nodebyte instance over the REST API.
+
+It is a single-file [FastMCP](https://github.com/modelcontextprotocol/python-sdk)
+server exposed over **streamable HTTP** on port `8080` at `/mcp`. It authenticates
+to the Nodebyte backend with a service-account email + password, caches the access
+token, and re-authenticates automatically when the token expires.
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `add_node` | Add one device/site/service (idempotent upsert by hostname/name) |
+| `add_nodes` | Bulk-add / upload many nodes at once |
+| `search_nodes` | Substring search across name/hostname/ip/url, filter by kind/tags |
+| `get_node` | Fetch a node by id |
+| `update_node` | Patch fields on a node |
+| `delete_node` | Delete a node |
+| `node_stats` | Totals + kinds/tags currently in use |
+| `list_teams` | List the service account's teams |
+
+## Configuration
+
+| Env | Default | Notes |
+|-----|---------|-------|
+| `NODEBYTE_BASE_URL` | `http://backend.nodebyte.svc.cluster.local:8000` | Nodebyte backend base URL |
+| `NODEBYTE_EMAIL` | *(required)* | Service-account email |
+| `NODEBYTE_PASSWORD` | *(required)* | Service-account password |
+| `NODEBYTE_TEAM_ID` | *(first team)* | Optional default team id |
+| `MCP_TOKEN` | *(none)* | If set, inbound requests must send `Authorization: Bearer <MCP_TOKEN>` |
+| `PORT` | `8080` | Listen port |
+
+The service account is an ordinary Nodebyte user; every tool operates within the
+teams that account is a member of. The login request sends a `NodebyteApp/1.0`
+User-Agent so it works even when Cloudflare Turnstile is enabled.
+
+## Run
+
+```bash
+pip install -r requirements.txt
+NODEBYTE_BASE_URL=http://localhost:8000 \
+NODEBYTE_EMAIL=you@example.com NODEBYTE_PASSWORD=secret \
+python server.py
+```
+
+Or via Docker:
+
+```bash
+docker build -t nodebyte-mcp .
+docker run -p 8080:8080 \
+  -e NODEBYTE_BASE_URL=http://host.docker.internal:8000 \
+  -e NODEBYTE_EMAIL=you@example.com -e NODEBYTE_PASSWORD=secret \
+  nodebyte-mcp
+```
+
+## Register with Claude Code
+
+```bash
+claude mcp add --transport http nodebyte https://<host>/mcp \
+  --header "Authorization: Bearer <MCP_TOKEN>"
+```

--- a/mcp/requirements.txt
+++ b/mcp/requirements.txt
@@ -1,0 +1,4 @@
+mcp>=1.9,<2
+httpx>=0.27,<1
+uvicorn>=0.30,<1
+starlette>=1.1,<2

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1,0 +1,339 @@
+"""Nodebyte MCP server.
+
+A FastMCP streamable-HTTP server that lets Claude add, upload, and search nodes
+in a Nodebyte digital-inventory instance. It authenticates to the Nodebyte REST
+API with a service account (email + password), caches the access token, and
+re-logs-in transparently when the token expires.
+
+Env:
+  NODEBYTE_BASE_URL   base URL of the Nodebyte backend, e.g.
+                      http://backend.nodebyte.svc.cluster.local:8000 (default)
+  NODEBYTE_EMAIL      service-account email (required)
+  NODEBYTE_PASSWORD   service-account password (required)
+  NODEBYTE_TEAM_ID    optional default team id; if unset, the account's first
+                      team is used
+  MCP_TOKEN           inbound bearer gate for Claude -> this server (optional)
+  PORT                listen port (default 8080)
+"""
+
+import os
+from typing import Any
+
+import httpx
+import uvicorn
+from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, PlainTextResponse
+
+NODEBYTE_BASE_URL = os.environ.get(
+    "NODEBYTE_BASE_URL", "http://backend.nodebyte.svc.cluster.local:8000"
+).rstrip("/")
+NODEBYTE_EMAIL = os.environ["NODEBYTE_EMAIL"]
+NODEBYTE_PASSWORD = os.environ["NODEBYTE_PASSWORD"]
+NODEBYTE_TEAM_ID = os.environ.get("NODEBYTE_TEAM_ID") or None
+MCP_TOKEN = os.environ.get("MCP_TOKEN")
+PORT = int(os.environ.get("PORT", "8080"))
+
+INSTRUCTIONS = """\
+Tools for a Nodebyte digital-inventory instance (https://nodebyte.internal.white.fm).
+Nodebyte tracks the devices, sites, and services an IT team depends on. Each entry is
+a "node" with a name, a kind, and optional hostname / ip / url / tags / notes.
+
+Adding inventory:
+  - Use add_node for a single device/site/service, or add_nodes to upload many at once.
+  - kind is one of device | site | service | other (free text is also accepted).
+  - name is the only required field. Provide hostname and/or ip and/or url when known.
+  - add_node/add_nodes upsert by default: if a node with the same hostname (or, when no
+    hostname is given, the same name) already exists in the team, it is updated in place
+    instead of duplicated. Pass upsert=false to always create a new node.
+
+Finding inventory:
+  - search_nodes does a case-insensitive substring match across name, hostname, ip and
+    url at once (the q argument), and can filter by kind/tags/has_url.
+  - node_stats returns totals plus the kinds and tags currently in use (use it to
+    discover which tags/kinds exist before searching or tagging).
+
+Teams: nodes live in a team. Every tool takes an optional team_id; when omitted the
+service account's first (or configured default) team is used. list_teams shows them.
+"""
+
+_security = TransportSecuritySettings(enable_dns_rebinding_protection=False)
+mcp = FastMCP(
+    "nodebyte",
+    instructions=INSTRUCTIONS,
+    host="0.0.0.0",
+    port=PORT,
+    transport_security=_security,
+)
+
+# Nodebyte skips Cloudflare Turnstile on login when the User-Agent starts with
+# "NodebyteApp/", so this client authenticates even if Turnstile is enabled.
+_client = httpx.AsyncClient(
+    base_url=NODEBYTE_BASE_URL,
+    headers={"User-Agent": "NodebyteApp/1.0"},
+    timeout=30.0,
+)
+
+_access_token: str | None = None
+_default_team_id: str | None = NODEBYTE_TEAM_ID
+
+
+async def _login() -> str:
+    global _access_token
+    resp = await _client.post(
+        "/api/auth/login",
+        json={"email": NODEBYTE_EMAIL, "password": NODEBYTE_PASSWORD},
+    )
+    if resp.status_code >= 400:
+        raise RuntimeError(f"nodebyte login failed -> {resp.status_code}: {resp.text[:300]}")
+    _access_token = resp.json()["access_token"]
+    return _access_token
+
+
+async def _req(method: str, path: str, *, params: dict | None = None, json: Any = None) -> Any:
+    """Call the Nodebyte API with the cached bearer, re-logging-in once on 401."""
+    global _access_token
+    if _access_token is None:
+        await _login()
+    for attempt in (1, 2):
+        headers = {"Authorization": f"Bearer {_access_token}"}
+        resp = await _client.request(method, path, params=params, json=json, headers=headers)
+        if resp.status_code == 401 and attempt == 1:
+            await _login()
+            continue
+        if resp.status_code >= 400:
+            raise RuntimeError(f"nodebyte {method} {path} -> {resp.status_code}: {resp.text[:500]}")
+        if resp.status_code == 204:
+            return None
+        if resp.headers.get("content-type", "").startswith("application/json"):
+            return resp.json()
+        return resp.text
+    raise RuntimeError(f"nodebyte {method} {path} -> unauthorized after re-login")
+
+
+async def _resolve_team(team_id: str | None) -> str:
+    global _default_team_id
+    if team_id:
+        return team_id
+    if _default_team_id:
+        return _default_team_id
+    teams = await _req("GET", "/api/teams")
+    if not teams:
+        raise RuntimeError("service account belongs to no teams; create one in Nodebyte first")
+    _default_team_id = teams[0]["id"]
+    return _default_team_id
+
+
+def _node_body(fields: dict) -> dict:
+    body: dict = {}
+    for key, value in fields.items():
+        if value is None:
+            continue
+        body[key] = value
+    return body
+
+
+async def _find_node(team_id: str, hostname: str | None, name: str) -> dict | None:
+    """Return an existing node matched by hostname (preferred) else exact name, or None."""
+    query = hostname or name
+    matches = await _req(
+        "GET", f"/api/teams/{team_id}/nodes", params={"q": query, "limit": 200}
+    )
+    for node in matches:
+        if hostname:
+            if node.get("hostname") == hostname:
+                return node
+        elif node.get("name") == name and not node.get("hostname"):
+            return node
+    return None
+
+
+@mcp.tool()
+async def list_teams() -> list[dict]:
+    """List the teams the service account belongs to (id, name, slug, my_role).
+
+    Every other tool accepts an optional team_id; use this to find the id when you
+    need to target a team other than the default (first) one.
+    """
+    return await _req("GET", "/api/teams")
+
+
+@mcp.tool()
+async def add_node(
+    name: str,
+    kind: str = "device",
+    hostname: str | None = None,
+    ip: str | None = None,
+    url: str | None = None,
+    tags: list[str] | None = None,
+    notes: str | None = None,
+    meta: dict | None = None,
+    team_id: str | None = None,
+    upsert: bool = True,
+) -> dict:
+    """Add a single node (device / site / service) to the inventory.
+
+    Only `name` is required. `kind` is one of device | site | service | other (free
+    text is accepted too). Provide `hostname`, `ip`, and/or `url` when known; `tags`
+    is a list of labels; `meta` is a free-form dict for extra structured data.
+
+    When upsert is true (default) and a node with the same hostname already exists in
+    the team (or, if no hostname is given, a hostname-less node with the same name),
+    that node is updated in place instead of creating a duplicate. Pass upsert=false to
+    always create a new node. Returns the created or updated node.
+    """
+    tid = await _resolve_team(team_id)
+    body = _node_body(
+        {"name": name, "kind": kind, "hostname": hostname, "ip": ip, "url": url,
+         "tags": tags, "notes": notes, "meta": meta}
+    )
+    if upsert:
+        existing = await _find_node(tid, hostname, name)
+        if existing:
+            return await _req("PATCH", f"/api/teams/{tid}/nodes/{existing['id']}", json=body)
+    return await _req("POST", f"/api/teams/{tid}/nodes", json=body)
+
+
+@mcp.tool()
+async def add_nodes(
+    nodes: list[dict],
+    team_id: str | None = None,
+    upsert: bool = True,
+) -> dict:
+    """Bulk-add / upload many nodes at once.
+
+    `nodes` is a list of node objects, each accepting the same fields as add_node
+    (name required; optional kind, hostname, ip, url, tags, notes, meta). upsert
+    applies per node exactly as in add_node. Returns
+    {"created": n, "updated": n, "errors": [{"name": ..., "error": ...}]}.
+    """
+    tid = await _resolve_team(team_id)
+    created = 0
+    updated = 0
+    errors: list[dict] = []
+    for entry in nodes:
+        name = entry.get("name")
+        if not name:
+            errors.append({"name": None, "error": "missing required field 'name'"})
+            continue
+        hostname = entry.get("hostname")
+        body = _node_body(
+            {"name": name, "kind": entry.get("kind", "device"), "hostname": hostname,
+             "ip": entry.get("ip"), "url": entry.get("url"), "tags": entry.get("tags"),
+             "notes": entry.get("notes"), "meta": entry.get("meta")}
+        )
+        try:
+            existing = await _find_node(tid, hostname, name) if upsert else None
+            if existing:
+                await _req("PATCH", f"/api/teams/{tid}/nodes/{existing['id']}", json=body)
+                updated += 1
+            else:
+                await _req("POST", f"/api/teams/{tid}/nodes", json=body)
+                created += 1
+        except Exception as exc:  # noqa: BLE001 - report per-node, keep going
+            errors.append({"name": name, "error": str(exc)})
+    return {"created": created, "updated": updated, "errors": errors}
+
+
+@mcp.tool()
+async def search_nodes(
+    q: str | None = None,
+    kind: list[str] | None = None,
+    tags: list[str] | None = None,
+    has_url: bool | None = None,
+    is_orphan: bool | None = None,
+    limit: int = 50,
+    offset: int = 0,
+    team_id: str | None = None,
+) -> list[dict]:
+    """Search the inventory.
+
+    `q` is a case-insensitive substring matched across name, hostname, ip and url at
+    once. `kind` filters to one or more kinds; `tags` requires the node to carry all
+    listed tags; `has_url` / `is_orphan` are boolean filters. limit is 1-200 (default
+    50). Returns matching nodes, newest-updated first.
+    """
+    params: dict = {"limit": limit, "offset": offset}
+    if q:
+        params["q"] = q
+    if kind:
+        params["kind"] = kind
+    if tags:
+        params["tags"] = tags
+    if has_url is not None:
+        params["has_url"] = has_url
+    if is_orphan is not None:
+        params["is_orphan"] = is_orphan
+    tid = await _resolve_team(team_id)
+    return await _req("GET", f"/api/teams/{tid}/nodes", params=params)
+
+
+@mcp.tool()
+async def get_node(node_id: str, team_id: str | None = None) -> dict:
+    """Fetch a single node by its id."""
+    tid = await _resolve_team(team_id)
+    return await _req("GET", f"/api/teams/{tid}/nodes/{node_id}")
+
+
+@mcp.tool()
+async def update_node(
+    node_id: str,
+    name: str | None = None,
+    kind: str | None = None,
+    hostname: str | None = None,
+    ip: str | None = None,
+    url: str | None = None,
+    tags: list[str] | None = None,
+    notes: str | None = None,
+    meta: dict | None = None,
+    team_id: str | None = None,
+) -> dict:
+    """Update fields on an existing node by id. Only the fields you pass are changed.
+
+    Passing `tags` replaces the whole tag list. Same field meanings as add_node.
+    """
+    tid = await _resolve_team(team_id)
+    body = _node_body(
+        {"name": name, "kind": kind, "hostname": hostname, "ip": ip, "url": url,
+         "tags": tags, "notes": notes, "meta": meta}
+    )
+    return await _req("PATCH", f"/api/teams/{tid}/nodes/{node_id}", json=body)
+
+
+@mcp.tool()
+async def delete_node(node_id: str, team_id: str | None = None) -> dict:
+    """Delete a node by id."""
+    tid = await _resolve_team(team_id)
+    await _req("DELETE", f"/api/teams/{tid}/nodes/{node_id}")
+    return {"deleted": node_id}
+
+
+@mcp.tool()
+async def node_stats(team_id: str | None = None) -> dict:
+    """Inventory summary: total count, counts by kind, and the top tags in use.
+
+    Use this to discover which kinds and tags exist before searching or tagging.
+    """
+    tid = await _resolve_team(team_id)
+    return await _req("GET", f"/api/teams/{tid}/nodes/stats")
+
+
+class TokenAuth(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        if MCP_TOKEN and request.url.path != "/healthz":
+            if request.headers.get("authorization", "") != f"Bearer {MCP_TOKEN}":
+                return JSONResponse({"error": "unauthorized"}, status_code=401)
+        return await call_next(request)
+
+
+def main() -> None:
+    app = mcp.streamable_http_app()
+    app.add_middleware(TokenAuth)
+    app.add_route("/healthz", lambda _req: PlainTextResponse("ok"), methods=["GET"])
+    uvicorn.run(app, host="0.0.0.0", port=PORT)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds `mcp/` — a [Model Context Protocol](https://modelcontextprotocol.io) server that lets an MCP client (Claude, etc.) add, upload, and search nodes in a Nodebyte instance over the existing REST API.

It's a single-file [FastMCP](https://github.com/modelcontextprotocol/python-sdk) server exposed over **streamable HTTP** at `/mcp` (port 8080). It authenticates with a service-account email + password, caches the access token, and re-authenticates automatically on expiry. The login request sends a `NodebyteApp/1.0` User-Agent so it works even when Turnstile is enabled.

### Tools
| Tool | Purpose |
|------|---------|
| `add_node` | Add one device/site/service (idempotent upsert by hostname/name) |
| `add_nodes` | Bulk-add / upload many nodes |
| `search_nodes` | Substring search across name/hostname/ip/url, filter by kind/tags |
| `get_node` / `update_node` / `delete_node` | Node CRUD |
| `node_stats` | Totals + kinds/tags in use |
| `list_teams` | List the service account's teams |

### Files
- `mcp/server.py` — the server
- `mcp/requirements.txt`, `mcp/Dockerfile` — deps + container (mirrors the repo's style)
- `mcp/README.md` — configuration and usage

Config is via env (`NODEBYTE_BASE_URL`, `NODEBYTE_EMAIL`, `NODEBYTE_PASSWORD`, optional `NODEBYTE_TEAM_ID`, `MCP_TOKEN`). No changes to the backend, frontend, or extension.

The tool logic (login, team resolution, idempotent upsert, re-login-on-401, batch accounting) was verified end-to-end against a mock of the nodebyte API.