### PR TITLE
deps(frontend): bump Docker base to node:22-alpine (Node 20 EOL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
## Why

Node 20 reached end-of-life in ~April 2026 and no longer receives security updates. Plane issue: [SEC] Bump frontend Docker base off EOL Node 20 (NBYTE, priority high).

## Changes

- `frontend/Dockerfile`: base image `node:20-alpine` -> `node:22-alpine` (current LTS)
- `.github/workflows/ci.yml`: `setup-node` pin `node-version: 20` -> `22` to match

No other changes.

## Verification

- `docker build ./frontend` succeeds on the new base
- `node --version` inside the built image: **v22.23.1**
- All frontend dependency engine ranges in the lockfile are compatible with Node 22

## Note

Two untracked files in the local prod setup (`frontend/Dockerfile.prod`, `backend/Dockerfile.prod`) are not in git; the frontend one also pins `node:20-alpine` and should be updated separately when/if it is committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Jg3x1finPXvSEdKzCHztA