### PR TITLE
sec(mcp): fail closed without MCP_TOKEN, bind 127.0.0.1, enable DNS-rebinding protection

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -5,9 +5,13 @@ A [Model Context Protocol](https://modelcontextprotocol.io) server for
 search nodes in a Nodebyte instance over the REST API.
 
 It is a single-file [FastMCP](https://github.com/modelcontextprotocol/python-sdk)
-server exposed over **streamable HTTP** on port `8080` at `/mcp`. It authenticates
-to the Nodebyte backend with a service-account email + password, caches the access
-token, and re-authenticates automatically when the token expires.
+server exposed over **streamable HTTP** on `127.0.0.1:8080` at `/mcp`. It
+authenticates to the Nodebyte backend with a service-account email + password,
+caches the access token, and re-authenticates automatically when the token expires.
+
+Inbound requests must carry `Authorization: Bearer <MCP_TOKEN>`; the server
+refuses to start if `MCP_TOKEN` is unset. DNS-rebinding protection is enabled:
+the `Host` header must match `MCP_ALLOWED_HOSTS`.
 
 ## Tools
 
@@ -30,8 +34,11 @@ token, and re-authenticates automatically when the token expires.
 | `NODEBYTE_EMAIL` | *(required)* | Service-account email |
 | `NODEBYTE_PASSWORD` | *(required)* | Service-account password |
 | `NODEBYTE_TEAM_ID` | *(first team)* | Optional default team id |
-| `MCP_TOKEN` | *(none)* | If set, inbound requests must send `Authorization: Bearer <MCP_TOKEN>` |
+| `MCP_TOKEN` | *(required)* | Inbound requests must send `Authorization: Bearer <MCP_TOKEN>`; the server exits at startup if unset or empty |
+| `MCP_HOST` | `127.0.0.1` | Listen address; set to `0.0.0.0` only behind a trusted proxy or inside a container |
 | `PORT` | `8080` | Listen port |
+| `MCP_ALLOWED_HOSTS` | `127.0.0.1:*,localhost:*` | Comma-separated `Host` header allowlist (DNS-rebinding protection); add your public hostname (e.g. `mcp.example.com:*`) when serving non-locally |
+| `MCP_ALLOWED_ORIGINS` | *(empty)* | Comma-separated `Origin` header allowlist; requests without an `Origin` header always pass |
 
 The service account is an ordinary Nodebyte user; every tool operates within the
 teams that account is a member of. The login request sends a `NodebyteApp/1.0`
@@ -43,16 +50,19 @@ User-Agent so it works even when Cloudflare Turnstile is enabled.
 pip install -r requirements.txt
 NODEBYTE_BASE_URL=http://localhost:8000 \
 NODEBYTE_EMAIL=you@example.com NODEBYTE_PASSWORD=secret \
+MCP_TOKEN="$(openssl rand -hex 32)" \
 python server.py
 ```
 
-Or via Docker:
+Or via Docker (the container must bind `0.0.0.0` for `-p` to work; the published
+port is still gated by `MCP_TOKEN`):
 
 ```bash
 docker build -t nodebyte-mcp .
 docker run -p 8080:8080 \
   -e NODEBYTE_BASE_URL=http://host.docker.internal:8000 \
   -e NODEBYTE_EMAIL=you@example.com -e NODEBYTE_PASSWORD=secret \
+  -e MCP_TOKEN=change-me -e MCP_HOST=0.0.0.0 \
   nodebyte-mcp
 ```
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -12,11 +12,20 @@ Env:
   NODEBYTE_PASSWORD   service-account password (required)
   NODEBYTE_TEAM_ID    optional default team id; if unset, the account's first
                       team is used
-  MCP_TOKEN           inbound bearer gate for Claude -> this server (optional)
+  MCP_TOKEN           inbound bearer gate for Claude -> this server (required;
+                      the server refuses to start without it)
+  MCP_HOST            listen address (default 127.0.0.1)
   PORT                listen port (default 8080)
+  MCP_ALLOWED_HOSTS   comma-separated Host header allowlist for DNS-rebinding
+                      protection (default "127.0.0.1:*,localhost:*"; set this
+                      when serving on a non-localhost hostname)
+  MCP_ALLOWED_ORIGINS comma-separated Origin header allowlist (default empty:
+                      requests without an Origin header pass, cross-origin
+                      browser requests are rejected)
 """
 
 import os
+import secrets
 from typing import Any
 
 import httpx
@@ -33,11 +42,25 @@ NODEBYTE_BASE_URL = os.environ.get(
 NODEBYTE_EMAIL = os.environ["NODEBYTE_EMAIL"]
 NODEBYTE_PASSWORD = os.environ["NODEBYTE_PASSWORD"]
 NODEBYTE_TEAM_ID = os.environ.get("NODEBYTE_TEAM_ID") or None
-MCP_TOKEN = os.environ.get("MCP_TOKEN")
+MCP_TOKEN = os.environ.get("MCP_TOKEN", "")
+if not MCP_TOKEN:
+    raise SystemExit(
+        "MCP_TOKEN is not set (or empty). It is the inbound auth gate for this "
+        "server; refusing to start unauthenticated. Set MCP_TOKEN to a strong secret."
+    )
+MCP_HOST = os.environ.get("MCP_HOST", "127.0.0.1")
 PORT = int(os.environ.get("PORT", "8080"))
+MCP_ALLOWED_HOSTS = [
+    h.strip()
+    for h in os.environ.get("MCP_ALLOWED_HOSTS", "127.0.0.1:*,localhost:*").split(",")
+    if h.strip()
+]
+MCP_ALLOWED_ORIGINS = [
+    o.strip() for o in os.environ.get("MCP_ALLOWED_ORIGINS", "").split(",") if o.strip()
+]
 
 INSTRUCTIONS = """\
-Tools for a Nodebyte digital-inventory instance (https://nodebyte.internal.white.fm).
+Tools for a Nodebyte digital-inventory instance (the deployment at NODEBYTE_BASE_URL).
 Nodebyte tracks the devices, sites, and services an IT team depends on. Each entry is
 a "node" with a name, a kind, and optional hostname / ip / url / tags / notes.
 
@@ -59,11 +82,15 @@ Teams: nodes live in a team. Every tool takes an optional team_id; when omitted 
 service account's first (or configured default) team is used. list_teams shows them.
 """
 
-_security = TransportSecuritySettings(enable_dns_rebinding_protection=False)
+_security = TransportSecuritySettings(
+    enable_dns_rebinding_protection=True,
+    allowed_hosts=MCP_ALLOWED_HOSTS,
+    allowed_origins=MCP_ALLOWED_ORIGINS,
+)
 mcp = FastMCP(
     "nodebyte",
     instructions=INSTRUCTIONS,
-    host="0.0.0.0",
+    host=MCP_HOST,
     port=PORT,
     transport_security=_security,
 )
@@ -322,8 +349,10 @@ async def node_stats(team_id: str | None = None) -> dict:
 
 class TokenAuth(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
-        if MCP_TOKEN and request.url.path != "/healthz":
-            if request.headers.get("authorization", "") != f"Bearer {MCP_TOKEN}":
+        if request.url.path != "/healthz":
+            expected = f"Bearer {MCP_TOKEN}".encode()
+            provided = request.headers.get("authorization", "").encode()
+            if not secrets.compare_digest(provided, expected):
                 return JSONResponse({"error": "unauthorized"}, status_code=401)
         return await call_next(request)
 
@@ -332,7 +361,7 @@ def main() -> None:
     app = mcp.streamable_http_app()
     app.add_middleware(TokenAuth)
     app.add_route("/healthz", lambda _req: PlainTextResponse("ok"), methods=["GET"])
-    uvicorn.run(app, host="0.0.0.0", port=PORT)
+    uvicorn.run(app, host=MCP_HOST, port=PORT)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Security review findings (MCP server from #15)

A review of `mcp/server.py` found four unsafe defaults that had to be fixed before deployment:

1. **Auth was optional (fail-open).** `MCP_TOKEN` was read with `os.environ.get(...)` and the `TokenAuth` middleware only enforced the bearer check `if MCP_TOKEN` — deploying without the env var silently exposed all 8 tools (node CRUD, bulk add, etc.) unauthenticated.
2. **Bound to `0.0.0.0` with DNS-rebinding protection explicitly disabled.** The server passed `TransportSecuritySettings(enable_dns_rebinding_protection=False)` and hardcoded `host="0.0.0.0"` in both the FastMCP constructor and `uvicorn.run`.
3. **Contributor's personal URL** (`nodebyte.internal.white.fm`) was embedded in the tool INSTRUCTIONS text sent to every MCP client.
4. **Timing-unsafe token comparison** — the bearer token was checked with `==`.

## Fixes

- `MCP_TOKEN` is now **required**: the server exits at startup with a clear error when it is unset or empty (fail closed).
- Default bind is now **`127.0.0.1`**, overridable via new `MCP_HOST` env var (Docker users set `MCP_HOST=0.0.0.0`; README updated).
- **DNS-rebinding protection enabled** (`enable_dns_rebinding_protection=True`). Per the mcp 1.28.x API this requires a Host-header allowlist, so it is wired to `MCP_ALLOWED_HOSTS` (default `127.0.0.1:*,localhost:*`) and `MCP_ALLOWED_ORIGINS` (default empty; requests without an Origin header pass, matching non-browser MCP clients).
- Personal URL replaced with a generic reference to the `NODEBYTE_BASE_URL` deployment.
- Token check now uses `secrets.compare_digest` on the raw header bytes.
- `mcp/README.md` updated: MCP_TOKEN required, default bind 127.0.0.1, new env vars documented, run/Docker examples fixed.

## Verification (venv with `mcp==1.28.1`, no real backend)

- `py_compile` passes.
- Unset `MCP_TOKEN` → exits 1: `MCP_TOKEN is not set (or empty). It is the inbound auth gate for this server; refusing to start unauthenticated...` (same for empty string).
- With dummy creds + token: `ss -tlnp` shows `LISTEN 127.0.0.1:18099` (not 0.0.0.0).
- `/healthz` → 200 without auth; `/mcp` without / with wrong token → 401; with correct token → full `initialize` response (instructions no longer contain the personal URL).
- Forged `Host: evil.example.com` with a valid token → **421 Invalid Host header** (rebinding protection active).

Plane issue: `[SEC] Harden MCP server defaults before deployment` (8e30800c). Do not merge without owner approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Jg3x1finPXvSEdKzCHztA