### PR TITLE
Add hardened production Compose deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Validate production Compose definition
+        env:
+          POSTGRES_PASSWORD: ci-dummy-password
+          FRONTEND_ORIGIN: https://nodebyte.example.com
+          JWT_SECRET: ci-dummy-jwt-secret
+          TURNSTILE_SECRET_KEY: ci-dummy-turnstile-secret
+          NEXT_PUBLIC_API_BASE_URL: https://nodebyte.example.com/api
+          NEXT_PUBLIC_TURNSTILE_SITE_KEY: ci-dummy-turnstile-site-key
+        run: docker compose -f docker-compose.prod.yml config --quiet
+
       - uses: docker/setup-buildx-action@v3
 
       - name: Build backend image

--- a/README.md
+++ b/README.md
@@ -216,7 +216,19 @@ You must have a registered account and the backend running on `http://localhost:
 
 ## Production Deployment
 
-When deploying to production, address each item in this checklist:
+Use the production Compose definition so the application runs from immutable,
+non-root images without source-code bind mounts or a published database port:
+
+```bash
+docker compose -f docker-compose.prod.yml config
+docker compose -f docker-compose.prod.yml build
+docker compose -f docker-compose.prod.yml up -d --remove-orphans
+docker compose -f docker-compose.prod.yml ps
+```
+
+Back up the `nodebyte_postgres` volume before applying migrations. The backend
+production image applies Alembic migrations before starting Uvicorn. Address
+each item in this checklist before the rollout:
 
 - [ ] **`JWT_SECRET`** — set to a long random string (`openssl rand -hex 32`)
 - [ ] **`POSTGRES_PASSWORD`** — set to a strong, unique password
@@ -225,7 +237,7 @@ When deploying to production, address each item in this checklist:
 - [ ] **`FRONTEND_ORIGIN`** — set to your actual frontend URL (e.g. `https://nodebyte.example.com`)
 - [ ] **`NEXT_PUBLIC_API_BASE_URL`** — set to your actual API URL
 - [ ] **Turnstile** — replace test keys with real Cloudflare Turnstile keys, or set `TURNSTILE_ENABLED=false` to disable
-- [ ] **Uvicorn** — remove `--reload` from `backend/entrypoint.sh` and consider adding `--workers N`
+- [ ] **Compose** — use `docker-compose.prod.yml`, which runs Uvicorn without `--reload`
 - [ ] **HTTPS** — terminate TLS with a reverse proxy (nginx, Caddy, Traefik) in front of the containers
 - [ ] **Volumes** — ensure `nodebyte_postgres` is backed up or mapped to persistent storage
 
@@ -264,7 +276,8 @@ nodebyte/
 │   ├── manifest.json
 │   └── src/
 ├── scripts/              # Utility scripts
-├── docker-compose.yml
+├── docker-compose.yml       # local development
+├── docker-compose.prod.yml  # hardened production runtime
 └── create-extension.sh
 ```
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,88 @@
+services:
+  db:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-nodebyte}
+      POSTGRES_USER: ${POSTGRES_USER:-nodebyte}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
+    volumes:
+      - nodebyte_postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    security_opt:
+      - no-new-privileges:true
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.prod
+    restart: unless-stopped
+    init: true
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-nodebyte}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-nodebyte}
+      FRONTEND_ORIGIN: ${FRONTEND_ORIGIN:?FRONTEND_ORIGIN must be set}
+      PYTHONPATH: /app
+      NODEBYTE_ENV: production
+      JWT_SECRET: ${JWT_SECRET:?JWT_SECRET must be set}
+      JWT_ISSUER: ${JWT_ISSUER:-nodebyte}
+      ACCESS_TOKEN_EXPIRES_MINUTES: ${ACCESS_TOKEN_EXPIRES_MINUTES:-15}
+      REFRESH_TOKEN_EXPIRES_DAYS: ${REFRESH_TOKEN_EXPIRES_DAYS:-30}
+      COOKIE_SECURE: ${COOKIE_SECURE:-true}
+      COOKIE_SAMESITE: ${COOKIE_SAMESITE:-lax}
+      REGISTRATION_ENABLED: ${REGISTRATION_ENABLED:-false}
+      TURNSTILE_SECRET_KEY: ${TURNSTILE_SECRET_KEY:?TURNSTILE_SECRET_KEY must be set}
+      TURNSTILE_ENABLED: ${TURNSTILE_ENABLED:-true}
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "8000:8000"
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "http://127.0.0.1:8000/healthz"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.prod
+      args:
+        NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:?NEXT_PUBLIC_API_BASE_URL must be set}
+        NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${NEXT_PUBLIC_TURNSTILE_SITE_KEY:?NEXT_PUBLIC_TURNSTILE_SITE_KEY must be set}
+        NEXT_PUBLIC_EDITION: ${NEXT_PUBLIC_EDITION:-cloud}
+    restart: unless-stopped
+    init: true
+    environment:
+      NODE_ENV: production
+    depends_on:
+      backend:
+        condition: service_healthy
+    ports:
+      - "3000:3000"
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - "fetch('http://127.0.0.1:3000/login').then(r => process.exit(r.status < 500 ? 0 : 1)).catch(() => process.exit(1))"
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+
+volumes:
+  nodebyte_postgres:

--- a/docs/SECURITY_AND_PRODUCT_REVIEW_2026-08-12.md
+++ b/docs/SECURITY_AND_PRODUCT_REVIEW_2026-08-12.md
@@ -9,8 +9,10 @@ that prevent the same classes of regression.
 
 Production topology was verified through the Catalyst Backoffice as the active
 Docker Compose deployment on `nodebyte-prod` (`nodebyte.tech`), proxied through the
-DigitalOcean edge. The exact production Git revision was not available from the
-Backoffice record and must be captured during the production deployment proof.
+DigitalOcean edge. Direct inventory found a clean `master` checkout at `49838be`
+before rollout. It also found that the live stack still used development Dockerfiles,
+source bind mounts, and a published Postgres port; the tracked production Compose
+definition added by this review removes those deployment risks.
 
 ## Security findings and disposition
 
@@ -24,6 +26,7 @@ Backoffice record and must be captured during the production deployment proof.
 | High | Frontend CI was broken after Next.js 16 removed `next lint`; unrelated PRs stayed red. | Migrated CI lint to ESLint's native CLI and current flat config. |
 | High | Backend CI used `pytest ... || true`, so missing or failing tests could never fail CI. | Removed the bypass, added security regression tests, and made Python dependency audit part of CI. |
 | High | The frontend build image and CI ran on end-of-life Node 20. | Migrated both to Node 22 LTS. |
+| High | Production used development images, bind-mounted the checkout into app containers, and published Postgres on the VM. | Added a validated `docker-compose.prod.yml` using non-root immutable images, no source bind mounts, no database host port, dropped application capabilities, and explicit health checks. |
 | Medium | Batch registration returned raw exception strings, which could expose database/internal details. | Server logs retain the traceback; clients receive a generic error. |
 | Medium | Dependency update automation was absent. | Added weekly Dependabot coverage for npm, backend/mcp pip, and GitHub Actions. |
 


### PR DESCRIPTION
## Summary

Production inventory found that the live NodeByte stack still used the development Dockerfiles, bind-mounted source code into both application containers, and published Postgres on the VM.

This adds a tracked production Compose definition that:

- uses the non-root production backend and frontend images
- removes application source bind mounts
- does not publish the database port
- requires production secrets and origins instead of unsafe defaults
- sets `NODEBYTE_ENV=production`
- adds explicit service health checks
- drops all application-container Linux capabilities
- validates the production Compose definition in CI
- documents the production deployment command and finding

## Validation

- `docker compose -f docker-compose.prod.yml config --quiet` passed
- rendered config confirms no database host port
- rendered config confirms no backend/frontend bind mounts
- rendered config selects `Dockerfile.prod` for both application services
- backend/frontend production images and non-root behavior already passed PR #20 CI and isolated runtime validation

This is the deployment follow-up to #20.
