### PR TITLE
Security hardening phase 2 and stale inventory review

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "23 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+          - python
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A modern digital inventory manager built for IT teams. Track every device, site,
 - **Browser extension** — add any website to your inventory with one click (Chrome, Manifest V3)
 - **Bookmark sync** — nodes with URLs automatically sync to browser bookmarks, organized by kind
 - **Bulk operations** — multi-select nodes to delete or tag in batch
+- **Stale inventory review** — triage inactive nodes in bulk, assign an owner, and keep, ignore, or retire them
 - **Invite system** — invite team members by email with role-based access
 - **Super admin console** — platform-wide user and team management for superusers
 
@@ -43,6 +44,7 @@ flowchart LR
     Extension["Chrome Extension"] --> Backend
     Frontend -->|"/api/*"| Backend["FastAPI\n:8000"]
     Backend --> DB[("PostgreSQL\n:5432")]
+    Backend --> Redis[("Redis\nrate limits")]
 ```
 
 The frontend proxies all `/api/*` requests to the backend, keeping auth cookies same-origin. The Chrome extension talks directly to the backend API.
@@ -135,6 +137,7 @@ All configuration is done through environment variables. Set them in your `.env`
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `DATABASE_URL` | PostgreSQL connection string | *(set by docker-compose)* |
+| `REDIS_URL` | Shared Redis connection for distributed rate limits | `redis://redis:6379/0` |
 | `JWT_SECRET` | Secret key for signing JWTs — **change in production** | *(required)* |
 | `JWT_ISSUER` | Issuer claim in JWTs | `nodebyte` |
 | `ACCESS_TOKEN_EXPIRES_MINUTES` | Access token lifetime | `15` |
@@ -240,6 +243,14 @@ each item in this checklist before the rollout:
 - [ ] **Compose** — use `docker-compose.prod.yml`, which runs Uvicorn without `--reload`
 - [ ] **HTTPS** — terminate TLS with a reverse proxy (nginx, Caddy, Traefik) in front of the containers
 - [ ] **Volumes** — ensure `nodebyte_postgres` is backed up or mapped to persistent storage
+
+Redis stores short-lived rate-limit windows only; it is intentionally not published
+to the host or persisted by the production Compose definition. Keep all backend
+replicas on the same `REDIS_URL` so abuse-control budgets remain global.
+
+Refresh tokens are single-use server-side sessions. Replaying a rotated token revokes
+the entire session family. Invite and registration secrets are shown once at creation;
+only SHA-256 lookup hashes and identifying prefixes are stored afterward.
 
 ## API Documentation
 

--- a/backend/alembic/versions/0006_security_sessions_and_lifecycle.py
+++ b/backend/alembic/versions/0006_security_sessions_and_lifecycle.py
@@ -1,0 +1,128 @@
+"""security sessions, hashed opaque tokens, and node lifecycle
+
+Revision ID: 0006_security_sessions
+Revises: 0005_api_tokens
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0006_security_sessions"
+down_revision = "0005_api_tokens"
+branch_labels = None
+depends_on = None
+
+
+def _hash_existing_tokens(table: str) -> None:
+    bind = op.get_bind()
+    rows = bind.execute(sa.text(f"select id, token from {table}")).all()
+    for row_id, token in rows:
+        token_hash = hashlib.sha256(token.encode("utf-8")).hexdigest()
+        bind.execute(
+            sa.text(
+                f"update {table} set token_hash = :token_hash, token_prefix = :token_prefix "
+                "where id = :row_id"
+            ),
+            {"token_hash": token_hash, "token_prefix": token[:16], "row_id": row_id},
+        )
+
+
+def upgrade() -> None:
+    op.create_table(
+        "refresh_sessions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("family_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("replaced_by_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("created_ip", sa.String(length=64), nullable=True),
+        sa.Column("user_agent", sa.String(length=500), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["replaced_by_id"], ["refresh_sessions.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("token_hash"),
+    )
+    op.create_index("ix_refresh_sessions_user_id", "refresh_sessions", ["user_id"])
+    op.create_index("ix_refresh_sessions_family_id", "refresh_sessions", ["family_id"])
+    op.create_index("ix_refresh_sessions_token_hash", "refresh_sessions", ["token_hash"], unique=True)
+
+    for table in ("invites", "registration_tokens"):
+        op.add_column(table, sa.Column("token_hash", sa.String(length=64), nullable=True))
+        op.add_column(table, sa.Column("token_prefix", sa.String(length=20), nullable=True))
+        _hash_existing_tokens(table)
+
+    op.drop_index("ix_invites_token", table_name="invites")
+    op.drop_column("invites", "token")
+    op.alter_column("invites", "token_hash", nullable=False)
+    op.alter_column("invites", "token_prefix", nullable=False)
+    op.create_index("ix_invites_token_hash", "invites", ["token_hash"], unique=True)
+
+    op.drop_index("ix_registration_tokens_token", table_name="registration_tokens")
+    op.drop_column("registration_tokens", "token")
+    op.alter_column("registration_tokens", "token_hash", nullable=False)
+    op.alter_column("registration_tokens", "token_prefix", nullable=False)
+    op.create_index(
+        "ix_registration_tokens_token_hash",
+        "registration_tokens",
+        ["token_hash"],
+        unique=True,
+    )
+
+    op.add_column(
+        "nodes",
+        sa.Column("lifecycle_status", sa.String(length=20), server_default="active", nullable=False),
+    )
+    op.add_column("nodes", sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("nodes", sa.Column("reviewed_by_id", postgresql.UUID(as_uuid=True), nullable=True))
+    op.add_column("nodes", sa.Column("owner_user_id", postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_foreign_key(
+        "fk_nodes_reviewed_by_id_users", "nodes", "users", ["reviewed_by_id"], ["id"], ondelete="SET NULL"
+    )
+    op.create_foreign_key(
+        "fk_nodes_owner_user_id_users", "nodes", "users", ["owner_user_id"], ["id"], ondelete="SET NULL"
+    )
+    op.create_index("ix_nodes_lifecycle_status", "nodes", ["team_id", "lifecycle_status"])
+    op.create_index("ix_nodes_last_seen_at", "nodes", ["team_id", "last_seen_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_nodes_last_seen_at", table_name="nodes")
+    op.drop_index("ix_nodes_lifecycle_status", table_name="nodes")
+    op.drop_constraint("fk_nodes_owner_user_id_users", "nodes", type_="foreignkey")
+    op.drop_constraint("fk_nodes_reviewed_by_id_users", "nodes", type_="foreignkey")
+    op.drop_column("nodes", "owner_user_id")
+    op.drop_column("nodes", "reviewed_by_id")
+    op.drop_column("nodes", "reviewed_at")
+    op.drop_column("nodes", "lifecycle_status")
+
+    for table, length in (("invites", 64), ("registration_tokens", 128)):
+        op.add_column(table, sa.Column("token", sa.String(length=length), nullable=True))
+        bind = op.get_bind()
+        rows = bind.execute(sa.text(f"select id from {table}")).all()
+        for (row_id,) in rows:
+            bind.execute(
+                sa.text(f"update {table} set token = :token where id = :row_id"),
+                {"token": f"downgraded-{uuid.uuid4()}", "row_id": row_id},
+            )
+        op.alter_column(table, "token", nullable=False)
+        op.create_index(f"ix_{table}_token", table, ["token"], unique=True)
+        op.drop_index(f"ix_{table}_token_hash", table_name=table)
+        op.drop_column(table, "token_prefix")
+        op.drop_column(table, "token_hash")
+
+    op.drop_index("ix_refresh_sessions_token_hash", table_name="refresh_sessions")
+    op.drop_index("ix_refresh_sessions_family_id", table_name="refresh_sessions")
+    op.drop_index("ix_refresh_sessions_user_id", table_name="refresh_sessions")
+    op.drop_table("refresh_sessions")

--- a/backend/alembic/versions/0006_security_sessions_and_lifecycle.py
+++ b/backend/alembic/versions/0006_security_sessions_and_lifecycle.py
@@ -24,6 +24,8 @@ def _hash_existing_tokens(table: str) -> None:
     bind = op.get_bind()
     rows = bind.execute(sa.text(f"select id, token from {table}")).all()
     for row_id, token in rows:
+        # Existing values are generated high-entropy opaque tokens, not passwords.
+        # codeql[py/weak-sensitive-data-hashing]
         token_hash = hashlib.sha256(token.encode("utf-8")).hexdigest()
         bind.execute(
             sa.text(

--- a/backend/app/api/routes/admin.py
+++ b/backend/app/api/routes/admin.py
@@ -30,6 +30,8 @@ from app.schemas.admin import (
     AdminUserUpdate,
 )
 from app.services.users import get_user_by_email
+from app.services.api_tokens import revoke_all_api_tokens
+from app.services.refresh_sessions import revoke_all_refresh_sessions
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -177,6 +179,10 @@ async def admin_update_user(
         target.full_name = payload.full_name
     if payload.new_password is not None:
         target.password_hash = hash_password(payload.new_password)
+
+    if payload.new_password is not None or payload.is_active is False:
+        await revoke_all_api_tokens(db, user_id=target.id)
+        await revoke_all_refresh_sessions(db, user_id=target.id)
 
     await db.commit()
     target = await _load_user(db, user_id)

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import uuid
-
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
-from jwt import InvalidTokenError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -12,8 +9,6 @@ from app.core.config import settings
 from app.core.rate_limit import rate_limit_login, rate_limit_register
 from app.core.security import (
     create_access_token,
-    create_refresh_token,
-    decode_token,
     verify_password,
 )
 from app.core.slug import slugify
@@ -31,6 +26,13 @@ from app.schemas.auth import (
 from app.schemas.users import UserPublic, UserUpdate
 from app.services.api_tokens import revoke_all_api_tokens
 from app.services.invites import accept_invite, get_invite_by_token
+from app.services.refresh_sessions import (
+    RefreshSessionError,
+    issue_refresh_session,
+    revoke_all_refresh_sessions,
+    revoke_refresh_family,
+    rotate_refresh_session,
+)
 from app.services.teams import create_team_with_owner
 from app.services.users import authenticate, create_user, get_user_by_email, update_user
 
@@ -55,6 +57,20 @@ def _set_refresh_cookie(response: Response, token: str) -> None:
         max_age=settings.refresh_token_expires_days * 24 * 3600,
         path="/",
     )
+
+
+def _clear_refresh_cookie(response: Response) -> None:
+    response.delete_cookie(
+        REFRESH_COOKIE_NAME,
+        path="/",
+        secure=settings.cookie_secure,
+        samesite=settings.cookie_samesite,
+    )
+
+
+def _request_metadata(request: Request) -> tuple[str | None, str | None]:
+    ip = request.client.host if request.client else None
+    return ip, request.headers.get("user-agent")
 
 
 @router.get("/public-settings")
@@ -117,10 +133,12 @@ async def register(
             raise HTTPException(status_code=500, detail="Could not allocate team slug")
         await create_team_with_owner(db, name=payload.team_name.strip(), slug=slug, owner_user_id=user.id)
 
-    await db.commit()
-
     access = create_access_token(user_id=user.id)
-    refresh = create_refresh_token(user_id=user.id)
+    ip, user_agent = _request_metadata(request)
+    _, refresh = await issue_refresh_session(
+        db, user_id=user.id, ip=ip, user_agent=user_agent
+    )
+    await db.commit()
     _set_refresh_cookie(response, refresh)
     return TokenResponse(access_token=access, refresh_token=refresh)
 
@@ -144,7 +162,11 @@ async def login(
         raise HTTPException(status_code=400, detail="Invalid email or password")
 
     access = create_access_token(user_id=user.id)
-    refresh = create_refresh_token(user_id=user.id)
+    ip, user_agent = _request_metadata(request)
+    _, refresh = await issue_refresh_session(
+        db, user_id=user.id, ip=ip, user_agent=user_agent
+    )
+    await db.commit()
     _set_refresh_cookie(response, refresh)
     return TokenResponse(access_token=access, refresh_token=refresh)
 
@@ -159,27 +181,42 @@ async def refresh(
     token = request.cookies.get(REFRESH_COOKIE_NAME) or (body and body.refresh_token)
     if not token:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing refresh token")
+    ip, user_agent = _request_metadata(request)
     try:
-        payload = decode_token(token)
-        if payload.get("typ") != "refresh":
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
-        user_id = uuid.UUID(payload["sub"])
-    except (InvalidTokenError, KeyError, ValueError):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+        user_id, new_refresh = await rotate_refresh_session(
+            db, raw_token=token, ip=ip, user_agent=user_agent
+        )
+    except RefreshSessionError as exc:
+        await db.commit()
+        _clear_refresh_cookie(response)
+        detail = "Refresh token reuse detected; this session has been revoked" if exc.reuse_detected else "Invalid refresh token"
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=detail) from exc
 
     user = await db.get(User, user_id)
     if not user or not user.is_active:
+        await revoke_all_refresh_sessions(db, user_id=user_id)
+        await db.commit()
+        _clear_refresh_cookie(response)
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
 
+    await db.commit()
     access = create_access_token(user_id=user.id)
-    new_refresh = create_refresh_token(user_id=user.id)
     _set_refresh_cookie(response, new_refresh)
     return TokenResponse(access_token=access, refresh_token=new_refresh)
 
 
 @router.post("/logout", response_model=MessageResponse)
-async def logout(response: Response) -> MessageResponse:
-    response.delete_cookie(REFRESH_COOKIE_NAME, path="/")
+async def logout(
+    request: Request,
+    response: Response,
+    body: RefreshRequest | None = None,
+    db: AsyncSession = Depends(get_db),
+) -> MessageResponse:
+    token = request.cookies.get(REFRESH_COOKIE_NAME) or (body and body.refresh_token)
+    if token:
+        await revoke_refresh_family(db, raw_token=token)
+        await db.commit()
+    _clear_refresh_cookie(response)
     return MessageResponse(message="Logged out")
 
 
@@ -218,5 +255,6 @@ async def update_me(
     updated = await update_user(db, user=user, **kwargs)
     if "new_password" in fields:
         await revoke_all_api_tokens(db, user_id=user.id)
+        await revoke_all_refresh_sessions(db, user_id=user.id)
     await db.commit()
     return updated

--- a/backend/app/api/routes/invites.py
+++ b/backend/app/api/routes/invites.py
@@ -10,26 +10,26 @@ from app.api.deps import get_current_user
 from app.core.rbac import require_role
 from app.db.session import get_db
 from app.models.user import User
-from app.schemas.invites import InviteCreate, InviteInfo, InvitePublic
+from app.schemas.invites import InviteCreate, InviteCreated, InviteInfo, InvitePublic
 from app.services.invites import accept_invite, create_invite, get_invite_by_token, list_invites, revoke_invite
 
 router = APIRouter(tags=["invites"])
 
 
-def _invite_to_public(invite) -> dict:
+def _invite_to_public(invite, token: str | None = None) -> dict:
     return {
         "id": invite.id,
         "team_id": invite.team_id,
         "invited_email": invite.invited_email,
         "role": invite.role,
-        "token": invite.token,
+        "token_prefix": invite.token_prefix,
         "invited_by_email": invite.invited_by.email if invite.invited_by else None,
         "created_at": invite.created_at,
         "expires_at": invite.expires_at,
-    }
+    } | ({"token": token} if token is not None else {})
 
 
-@router.post("/teams/{team_id}/invites", response_model=InvitePublic, status_code=201)
+@router.post("/teams/{team_id}/invites", response_model=InviteCreated, status_code=201)
 async def create_team_invite(
     team_id: uuid.UUID,
     payload: InviteCreate,
@@ -38,7 +38,7 @@ async def create_team_invite(
 ) -> dict:
     await require_role(db, user=user, team_id=team_id, min_role="admin")
 
-    invite = await create_invite(
+    invite, token = await create_invite(
         db,
         team_id=team_id,
         invited_email=payload.email,
@@ -47,7 +47,7 @@ async def create_team_invite(
     )
     await db.commit()
     await db.refresh(invite, ["invited_by"])
-    return _invite_to_public(invite)
+    return _invite_to_public(invite, token)
 
 
 @router.get("/teams/{team_id}/invites", response_model=list[InvitePublic])

--- a/backend/app/api/routes/nodes.py
+++ b/backend/app/api/routes/nodes.py
@@ -10,17 +10,30 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.deps import get_current_user
 from app.core.rbac import require_role
 from app.db.session import get_db
+from app.models.membership import Membership
 from app.models.node import Node
 from app.models.user import User
-from app.schemas.nodes import BulkActionResponse, BulkDeleteRequest, BulkTagRequest, NodeCreate, NodePublic, NodeStats, NodeUpdate
+from app.schemas.nodes import (
+    BulkActionResponse,
+    BulkDeleteRequest,
+    BulkTagRequest,
+    NodeCreate,
+    NodePublic,
+    NodeStats,
+    NodeUpdate,
+    StaleReviewDecision,
+    StaleReviewQueue,
+)
 from app.services.ansible_inventory import build_ansible_inventory
 from app.services.nodes import (
     bulk_delete_nodes,
     bulk_update_tags,
+    apply_stale_review_decision,
     count_nodes,
     create_node,
     delete_node,
     get_node_stats,
+    get_stale_review_queue,
     get_node,
     list_nodes,
     update_node,
@@ -60,6 +73,8 @@ async def nodes_list(
     has_url: bool | None = Query(default=None),
     tags: list[str] | None = Query(default=None),
     is_orphan: bool | None = Query(default=None),
+    lifecycle_status: list[str] | None = Query(default=None),
+    stale_after_days: int | None = Query(default=None, ge=1, le=3650),
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
     user: User = Depends(get_current_user),
@@ -69,6 +84,7 @@ async def nodes_list(
     return await list_nodes(
         db, team_id=team_id, q=q, parent_id=parent_id,
         kind=kind, has_url=has_url, tags=tags, is_orphan=is_orphan,
+        lifecycle_status=lifecycle_status, stale_after_days=stale_after_days,
         limit=limit, offset=offset,
     )
 
@@ -94,9 +110,10 @@ async def nodes_create(
 
     node = await create_node(db, team_id=team_id, data=data)
     await db.commit()
-    # Ensure DB-generated fields are loaded for serialization.
-    await db.refresh(node)
-    return node
+    created = await get_node(db, team_id=team_id, node_id=node.id)
+    if created is None:  # pragma: no cover - defensive after a successful insert
+        raise HTTPException(status_code=500, detail="Node creation could not be verified")
+    return created
 
 
 @router.post("/bulk-delete", response_model=BulkActionResponse)
@@ -168,6 +185,51 @@ async def nodes_export_ansible(
     )
 
 
+@router.get("/stale-review", response_model=StaleReviewQueue)
+async def stale_review_queue(
+    team_id: uuid.UUID,
+    stale_after_days: int = Query(default=30, ge=1, le=3650),
+    limit: int = Query(default=200, ge=1, le=200),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> StaleReviewQueue:
+    await require_role(db, user=user, team_id=team_id, min_role="viewer")
+    return await get_stale_review_queue(
+        db,
+        team_id=team_id,
+        stale_after_days=stale_after_days,
+        limit=limit,
+    )
+
+
+@router.post("/stale-review/decide", response_model=BulkActionResponse)
+async def stale_review_decide(
+    team_id: uuid.UUID,
+    payload: StaleReviewDecision,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> BulkActionResponse:
+    await require_role(db, user=user, team_id=team_id, min_role="member")
+    if payload.owner_user_id is not None:
+        owner = await db.execute(
+            select(Membership.id)
+            .where(Membership.team_id == team_id)
+            .where(Membership.user_id == payload.owner_user_id)
+        )
+        if owner.scalar_one_or_none() is None:
+            raise HTTPException(status_code=400, detail="Owner must be a team member")
+    affected = await apply_stale_review_decision(
+        db,
+        team_id=team_id,
+        node_ids=payload.node_ids,
+        lifecycle_status=payload.lifecycle_status,
+        reviewed_by_id=user.id,
+        owner_user_id=payload.owner_user_id,
+    )
+    await db.commit()
+    return BulkActionResponse(affected=affected)
+
+
 @router.get("/{node_id}", response_model=NodePublic)
 async def nodes_get(
     team_id: uuid.UUID,
@@ -209,9 +271,10 @@ async def nodes_patch(
 
     node = await update_node(db, node=node, data=data)
     await db.commit()
-    # Ensure any server-side updates are loaded for serialization.
-    await db.refresh(node)
-    return node
+    updated = await get_node(db, team_id=team_id, node_id=node.id)
+    if updated is None:  # pragma: no cover - defensive after a successful update
+        raise HTTPException(status_code=500, detail="Node update could not be verified")
+    return updated
 
 
 @router.delete("/{node_id}", status_code=status.HTTP_204_NO_CONTENT, response_class=Response)
@@ -228,4 +291,3 @@ async def nodes_delete(
     await delete_node(db, node=node)
     await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
-

--- a/backend/app/api/routes/register_node.py
+++ b/backend/app/api/routes/register_node.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
 
 from app.core.rate_limit import (
     rate_limit_register_node,
     rate_limit_register_nodes_batch,
 )
 from app.db.session import get_db
+from app.models.node import Node
 from app.schemas.nodes import NodePublic
 from app.schemas.registration_tokens import (
     BatchNodeRegisterRequest,
@@ -62,8 +65,15 @@ async def register_node(
         response.status_code = 200
 
     await db.commit()
-    await db.refresh(node)
-    return node
+    result = await db.execute(
+        select(Node)
+        .options(joinedload(Node.owner), joinedload(Node.reviewed_by))
+        .where(Node.id == node.id)
+        .execution_options(populate_existing=True)
+    )
+    registered = result.scalar_one()
+    await db.refresh(registered, attribute_names=["owner", "reviewed_by"])
+    return registered
 
 
 @router.post("/register-nodes", response_model=BatchNodeRegisterResponse)

--- a/backend/app/api/routes/registration_tokens.py
+++ b/backend/app/api/routes/registration_tokens.py
@@ -9,7 +9,11 @@ from app.api.deps import get_current_user
 from app.core.rbac import require_role
 from app.db.session import get_db
 from app.models.user import User
-from app.schemas.registration_tokens import RegistrationTokenCreate, RegistrationTokenPublic
+from app.schemas.registration_tokens import (
+    RegistrationTokenCreate,
+    RegistrationTokenCreated,
+    RegistrationTokenPublic,
+)
 from app.services.registration_tokens import (
     create_registration_token,
     get_registration_token_by_id,
@@ -20,12 +24,14 @@ from app.services.registration_tokens import (
 router = APIRouter(prefix="/teams/{team_id}/registration-tokens", tags=["registration-tokens"])
 
 
-def _to_public(rt, created_by_email: str | None = None) -> dict:
+def _to_public(
+    rt, created_by_email: str | None = None, token: str | None = None
+) -> dict:
     return {
         "id": rt.id,
         "team_id": rt.team_id,
         "label": rt.label,
-        "token": rt.token,
+        "token_prefix": rt.token_prefix,
         "created_by_email": created_by_email or (rt.created_by.email if rt.created_by else None),
         "max_uses": rt.max_uses,
         "use_count": rt.use_count,
@@ -34,10 +40,10 @@ def _to_public(rt, created_by_email: str | None = None) -> dict:
         "is_active": rt.is_active,
         "is_usable": rt.is_usable,
         "created_at": rt.created_at,
-    }
+    } | ({"token": token} if token is not None else {})
 
 
-@router.post("", response_model=RegistrationTokenPublic, status_code=201)
+@router.post("", response_model=RegistrationTokenCreated, status_code=201)
 async def create_token(
     team_id: uuid.UUID,
     payload: RegistrationTokenCreate,
@@ -45,7 +51,7 @@ async def create_token(
     db: AsyncSession = Depends(get_db),
 ):
     await require_role(db, user=user, team_id=team_id, min_role="admin")
-    rt = await create_registration_token(
+    rt, token = await create_registration_token(
         db,
         team_id=team_id,
         label=payload.label,
@@ -55,7 +61,7 @@ async def create_token(
         expires_in_days=payload.expires_in_days,
     )
     await db.commit()
-    return _to_public(rt, created_by_email=user.email)
+    return _to_public(rt, created_by_email=user.email, token=token)
 
 
 @router.get("", response_model=list[RegistrationTokenPublic])

--- a/backend/app/core/api_tokens.py
+++ b/backend/app/core/api_tokens.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import secrets
 
-API_TOKEN_PREFIX = "nb_pat_"
+API_TOKEN_PREFIX = "nb_pat_"  # nosec B105
 
 
 def generate_api_token() -> str:

--- a/backend/app/core/api_tokens.py
+++ b/backend/app/core/api_tokens.py
@@ -12,7 +12,8 @@ def generate_api_token() -> str:
 
 
 def hash_api_token(token: str) -> str:
-    """Return the irreversible lookup value stored in the database."""
+    """Hash a generated 256-bit opaque token for equality lookup, not a password."""
+    # codeql[py/weak-sensitive-data-hashing]
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -10,6 +10,7 @@ class Settings(BaseSettings):
     nodebyte_env: str = "dev"
 
     database_url: str
+    redis_url: str = "redis://redis:6379/0"
 
     jwt_secret: str
     jwt_issuer: str = "nodebyte"
@@ -37,4 +38,3 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
-

--- a/backend/app/core/opaque_tokens.py
+++ b/backend/app/core/opaque_tokens.py
@@ -5,6 +5,8 @@ import secrets
 
 
 def hash_opaque_token(token: str) -> str:
+    """Hash a generated 256-bit opaque token for equality lookup, not a password."""
+    # codeql[py/weak-sensitive-data-hashing]
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
 
 

--- a/backend/app/core/opaque_tokens.py
+++ b/backend/app/core/opaque_tokens.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import hashlib
+import secrets
+
+
+def hash_opaque_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def generate_opaque_token(*, prefix: str, token_bytes: int = 32) -> tuple[str, str, str]:
+    token = f"{prefix}{secrets.token_urlsafe(token_bytes)}"
+    return token, hash_opaque_token(token), token[:16]

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -1,50 +1,74 @@
 from __future__ import annotations
 
 import ipaddress
-import time
-from collections import defaultdict
+import secrets
 from functools import lru_cache
-from threading import Lock
 
 from fastapi import HTTPException, Request, status
+from redis.asyncio import Redis
+from redis.exceptions import RedisError
 
+from app.core.config import settings
 from app.schemas.auth import LoginRequest
 
 
-class _RateLimiter:
-    """Simple in-memory sliding-window rate limiter (no external deps)."""
-
-    def __init__(self) -> None:
-        self._lock = Lock()
-        self._hits: dict[str, list[float]] = defaultdict(list)
-
-    def check(self, key: str, max_hits: int, window_seconds: int) -> None:
-        now = time.monotonic()
-        cutoff = now - window_seconds
-
-        with self._lock:
-            timestamps = self._hits[key]
-            self._hits[key] = [t for t in timestamps if t > cutoff]
-            if len(self._hits[key]) >= max_hits:
-                raise HTTPException(
-                    status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-                    detail="Too many requests. Please try again later.",
-                )
-            self._hits[key].append(now)
+_SLIDING_WINDOW_SCRIPT = """
+local current = redis.call('TIME')
+local now_ms = (tonumber(current[1]) * 1000) + math.floor(tonumber(current[2]) / 1000)
+local cutoff = now_ms - tonumber(ARGV[2])
+redis.call('ZREMRANGEBYSCORE', KEYS[1], 0, cutoff)
+local count = redis.call('ZCARD', KEYS[1])
+if count >= tonumber(ARGV[1]) then
+  redis.call('PEXPIRE', KEYS[1], ARGV[2])
+  return count + 1
+end
+redis.call('ZADD', KEYS[1], now_ms, ARGV[3])
+redis.call('PEXPIRE', KEYS[1], ARGV[2])
+return count + 1
+"""
 
 
-_limiter = _RateLimiter()
+@lru_cache(maxsize=1)
+def get_rate_limit_redis() -> Redis:
+    return Redis.from_url(settings.redis_url, encoding="utf-8", decode_responses=True)
+
+
+class _RedisRateLimiter:
+    def __init__(self, redis: Redis | None = None) -> None:
+        self._redis = redis
+
+    async def check(self, key: str, max_hits: int, window_seconds: int) -> None:
+        redis = self._redis or get_rate_limit_redis()
+        try:
+            count = await redis.eval(
+                _SLIDING_WINDOW_SCRIPT,
+                1,
+                f"nodebyte:rate-limit:{key}",
+                max_hits,
+                window_seconds * 1000,
+                secrets.token_urlsafe(18),
+            )
+        except RedisError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Request protection is temporarily unavailable",
+            ) from exc
+        if int(count) > max_hits:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="Too many requests. Please try again later.",
+            )
+
+
+_limiter = _RedisRateLimiter()
 
 
 @lru_cache(maxsize=1)
 def _trusted_networks() -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
-    from app.core.config import settings
-
     return [ipaddress.ip_network(cidr, strict=False) for cidr in settings.trusted_proxy_cidrs]
 
 
 def _is_trusted_proxy(host: str) -> bool:
-    """Check if the direct-connection IP is a trusted reverse proxy."""
     networks = _trusted_networks()
     if not networks:
         return False
@@ -55,52 +79,36 @@ def _is_trusted_proxy(host: str) -> bool:
     return any(addr in net for net in networks)
 
 
-def _client_ip(request: Request) -> str:
+def client_ip(request: Request) -> str:
     direct_ip = request.client.host if request.client else "unknown"
-
-    # Only trust forwarded headers when the request comes from a known proxy.
     if not _is_trusted_proxy(direct_ip):
         return direct_ip
-
     cf_ip = request.headers.get("cf-connecting-ip")
     if cf_ip:
         return cf_ip.strip()
-
     real_ip = request.headers.get("x-real-ip")
     if real_ip:
         return real_ip.strip()
-
     forwarded = request.headers.get("x-forwarded-for")
     if forwarded:
         return forwarded.split(",")[0].strip()
-
     return direct_ip
 
 
-def rate_limit_register(request: Request) -> None:
-    _limiter.check(f"register:{_client_ip(request)}", max_hits=5, window_seconds=3600)
+async def rate_limit_register(request: Request) -> None:
+    await _limiter.check(f"register:{client_ip(request)}", max_hits=5, window_seconds=3600)
 
 
-def rate_limit_login(request: Request, payload: LoginRequest) -> None:
-    """
-    Login rate limiting.
-
-    - Per-IP burst control to protect infrastructure
-    - Per-IP+email limit to prevent one user (or attacker) on a shared IP
-      from locking out everyone else
-    """
-    ip = _client_ip(request)
+async def rate_limit_login(request: Request, payload: LoginRequest) -> None:
+    ip = client_ip(request)
     email = str(payload.email).strip().lower()
-
-    _limiter.check(f"login-ip:{ip}", max_hits=60, window_seconds=60)
-    _limiter.check(f"login:{ip}:{email}", max_hits=10, window_seconds=60)
-
-
-def rate_limit_register_node(request: Request) -> None:
-    """Protect single-node registration from runaway agents and token probing."""
-    _limiter.check(f"register-node:{_client_ip(request)}", max_hits=30, window_seconds=60)
+    await _limiter.check(f"login-ip:{ip}", max_hits=60, window_seconds=60)
+    await _limiter.check(f"login:{ip}:{email}", max_hits=10, window_seconds=60)
 
 
-def rate_limit_register_nodes_batch(request: Request) -> None:
-    """Batch requests are more expensive, so give them a separate smaller budget."""
-    _limiter.check(f"register-nodes:{_client_ip(request)}", max_hits=6, window_seconds=60)
+async def rate_limit_register_node(request: Request) -> None:
+    await _limiter.check(f"register-node:{client_ip(request)}", max_hits=30, window_seconds=60)
+
+
+async def rate_limit_register_nodes_batch(request: Request) -> None:
+    await _limiter.check(f"register-nodes:{client_ip(request)}", max_hits=6, window_seconds=60)

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -40,14 +40,14 @@ def create_access_token(*, user_id: uuid.UUID) -> str:
     return jwt.encode(payload, settings.jwt_secret, algorithm="HS256")
 
 
-def create_refresh_token(*, user_id: uuid.UUID) -> str:
+def create_refresh_token(*, user_id: uuid.UUID, session_id: uuid.UUID) -> str:
     now = _now()
     exp = now + timedelta(days=settings.refresh_token_expires_days)
     payload = {
         "iss": settings.jwt_issuer,
         "sub": str(user_id),
         "typ": "refresh",
-        "jti": str(uuid.uuid4()),
+        "jti": str(session_id),
         "iat": int(now.timestamp()),
         "exp": int(exp.timestamp()),
     }
@@ -56,4 +56,3 @@ def create_refresh_token(*, user_id: uuid.UUID) -> str:
 
 def decode_token(token: str) -> dict:
     return jwt.decode(token, settings.jwt_secret, algorithms=["HS256"], issuer=settings.jwt_issuer)
-

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -3,7 +3,17 @@ from app.models.invite import Invite
 from app.models.membership import Membership
 from app.models.node import Node
 from app.models.registration_token import RegistrationToken
+from app.models.refresh_session import RefreshSession
 from app.models.team import Team
 from app.models.user import User
 
-__all__ = ["User", "Team", "Membership", "Node", "Invite", "RegistrationToken", "ApiToken"]
+__all__ = [
+    "User",
+    "Team",
+    "Membership",
+    "Node",
+    "Invite",
+    "RegistrationToken",
+    "ApiToken",
+    "RefreshSession",
+]

--- a/backend/app/models/invite.py
+++ b/backend/app/models/invite.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, String, func
+from sqlalchemy import DateTime, ForeignKey, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -17,7 +17,8 @@ class Invite(Base, UUIDPrimaryKeyMixin, TimestampMixin):
     team_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("teams.id", ondelete="CASCADE"), nullable=False, index=True)
     invited_email: Mapped[str] = mapped_column(String(320), nullable=False)
     role: Mapped[str] = mapped_column(String(20), nullable=False, default="member")
-    token: Mapped[str] = mapped_column(String(64), unique=True, index=True, nullable=False)
+    token_hash: Mapped[str] = mapped_column(String(64), unique=True, index=True, nullable=False)
+    token_prefix: Mapped[str] = mapped_column(String(20), nullable=False)
     invited_by_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/backend/app/models/node.py
+++ b/backend/app/models/node.py
@@ -38,6 +38,16 @@ class Node(Base, UUIDPrimaryKeyMixin, TimestampMixin):
 
     last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     last_seen_source: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    lifecycle_status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="active", server_default=text("'active'")
+    )
+    reviewed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    reviewed_by_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    owner_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
 
     team: Mapped["Team"] = relationship(back_populates="nodes")
     parent: Mapped["Node | None"] = relationship(
@@ -51,7 +61,17 @@ class Node(Base, UUIDPrimaryKeyMixin, TimestampMixin):
         back_populates="parent",
         foreign_keys=[parent_node_id],
     )
+    reviewed_by: Mapped["User | None"] = relationship(foreign_keys=[reviewed_by_id])
+    owner: Mapped["User | None"] = relationship(foreign_keys=[owner_user_id])
+
+    @property
+    def owner_email(self) -> str | None:
+        return self.owner.email if self.owner else None
+
+    @property
+    def reviewed_by_email(self) -> str | None:
+        return self.reviewed_by.email if self.reviewed_by else None
 
 
 from app.models.team import Team  # noqa: E402
-
+from app.models.user import User  # noqa: E402

--- a/backend/app/models/refresh_session.py
+++ b/backend/app/models/refresh_session.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+from app.models.common import TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class RefreshSession(Base, UUIDPrimaryKeyMixin, TimestampMixin):
+    __tablename__ = "refresh_sessions"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    family_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    token_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True, index=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    replaced_by_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("refresh_sessions.id", ondelete="SET NULL"), nullable=True
+    )
+    created_ip: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    user_agent: Mapped[str | None] = mapped_column(String(500), nullable=True)
+
+    user: Mapped["User"] = relationship()
+
+
+from app.models.user import User  # noqa: E402

--- a/backend/app/models/registration_token.py
+++ b/backend/app/models/registration_token.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text, text
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -18,7 +18,8 @@ class RegistrationToken(Base, UUIDPrimaryKeyMixin, TimestampMixin):
         UUID(as_uuid=True), ForeignKey("teams.id"), nullable=False, index=True
     )
     label: Mapped[str] = mapped_column(String(200), nullable=False)
-    token: Mapped[str] = mapped_column(String(128), nullable=False, unique=True, index=True)
+    token_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True, index=True)
+    token_prefix: Mapped[str] = mapped_column(String(20), nullable=False)
 
     created_by_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("users.id"), nullable=False

--- a/backend/app/schemas/invites.py
+++ b/backend/app/schemas/invites.py
@@ -14,7 +14,7 @@ class InviteCreate(BaseModel):
 
     def model_post_init(self, __context: object) -> None:
         if self.role not in VALID_ROLES or self.role == "owner":
-            raise ValueError(f"role must be one of: viewer, member, admin")
+            raise ValueError("role must be one of: viewer, member, admin")
 
 
 class InvitePublic(BaseModel):
@@ -22,12 +22,16 @@ class InvitePublic(BaseModel):
     team_id: uuid.UUID
     invited_email: str
     role: str
-    token: str
+    token_prefix: str
     invited_by_email: str | None = None
     created_at: datetime
     expires_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class InviteCreated(InvitePublic):
+    token: str
 
 
 class InviteInfo(BaseModel):

--- a/backend/app/schemas/nodes.py
+++ b/backend/app/schemas/nodes.py
@@ -46,6 +46,12 @@ class NodePublic(BaseModel):
     notes: str | None
     last_seen_at: datetime | None
     last_seen_source: str | None
+    lifecycle_status: str
+    reviewed_at: datetime | None
+    reviewed_by_id: uuid.UUID | None
+    reviewed_by_email: str | None = None
+    owner_user_id: uuid.UUID | None
+    owner_email: str | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -70,6 +76,31 @@ class BulkTagRequest(BaseModel):
 
 class BulkActionResponse(BaseModel):
     affected: int
+
+
+class StaleReviewDecision(BaseModel):
+    node_ids: list[uuid.UUID] = Field(min_length=1, max_length=200)
+    lifecycle_status: str
+    owner_user_id: uuid.UUID | None = None
+
+    @model_validator(mode="after")
+    def _valid_status(self) -> "StaleReviewDecision":
+        if self.lifecycle_status not in {"active", "ignored", "retired"}:
+            raise ValueError("lifecycle_status must be active, ignored, or retired")
+        return self
+
+
+class StaleReviewSummary(BaseModel):
+    stale_after_days: int
+    pending: int
+    ignored: int
+    retired: int
+    total_stale: int
+
+
+class StaleReviewQueue(BaseModel):
+    summary: StaleReviewSummary
+    nodes: list[NodePublic]
 
 
 class TagCount(BaseModel):
@@ -97,4 +128,3 @@ class IpSegmentCount(BaseModel):
     segment: str
     node_count: int
     address_count: int
-

--- a/backend/app/schemas/registration_tokens.py
+++ b/backend/app/schemas/registration_tokens.py
@@ -17,7 +17,7 @@ class RegistrationTokenPublic(BaseModel):
     id: uuid.UUID
     team_id: uuid.UUID
     label: str
-    token: str
+    token_prefix: str
     created_by_email: str | None = None
     max_uses: int | None
     use_count: int
@@ -26,6 +26,10 @@ class RegistrationTokenPublic(BaseModel):
     is_active: bool
     is_usable: bool
     created_at: datetime
+
+
+class RegistrationTokenCreated(RegistrationTokenPublic):
+    token: str
 
 
 class NodeRegisterRequest(BaseModel):

--- a/backend/app/services/invites.py
+++ b/backend/app/services/invites.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import secrets
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -10,8 +9,9 @@ from sqlalchemy.orm import joinedload
 
 from app.models.invite import Invite
 from app.models.membership import Membership
+from app.core.opaque_tokens import generate_opaque_token, hash_opaque_token
 
-INVITE_TOKEN_BYTES = 32
+INVITE_TOKEN_PREFIX = "nb_inv_"  # nosec B105
 INVITE_EXPIRY_DAYS = 7
 
 
@@ -22,19 +22,20 @@ async def create_invite(
     invited_email: str,
     role: str,
     invited_by_id: uuid.UUID,
-) -> Invite:
-    token = secrets.token_urlsafe(INVITE_TOKEN_BYTES)
+) -> tuple[Invite, str]:
+    token, token_hash, token_prefix = generate_opaque_token(prefix=INVITE_TOKEN_PREFIX)
     invite = Invite(
         team_id=team_id,
         invited_email=invited_email.lower().strip(),
         role=role,
-        token=token,
+        token_hash=token_hash,
+        token_prefix=token_prefix,
         invited_by_id=invited_by_id,
         expires_at=datetime.now(timezone.utc) + timedelta(days=INVITE_EXPIRY_DAYS),
     )
     db.add(invite)
     await db.flush()
-    return invite
+    return invite, token
 
 
 async def list_invites(db: AsyncSession, *, team_id: uuid.UUID) -> list[Invite]:
@@ -52,7 +53,7 @@ async def get_invite_by_token(db: AsyncSession, *, token: str) -> Invite | None:
     res = await db.execute(
         select(Invite)
         .options(joinedload(Invite.team))
-        .where(Invite.token == token)
+        .where(Invite.token_hash == hash_opaque_token(token))
     )
     return res.scalar_one_or_none()
 

--- a/backend/app/services/nodes.py
+++ b/backend/app/services/nodes.py
@@ -3,12 +3,20 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 import uuid
 
-from sqlalchemy import cast, delete as sa_delete, func, or_, select, text
+from sqlalchemy import and_, cast, delete as sa_delete, func, or_, select, text, update
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
 
 from app.models.node import Node
-from app.schemas.nodes import IpSegmentCount, NodeLastSeenStats, NodeStats, TagCount
+from app.schemas.nodes import (
+    IpSegmentCount,
+    NodeLastSeenStats,
+    NodeStats,
+    StaleReviewQueue,
+    StaleReviewSummary,
+    TagCount,
+)
 
 
 async def list_nodes(
@@ -21,10 +29,17 @@ async def list_nodes(
     has_url: bool | None = None,
     tags: list[str] | None = None,
     is_orphan: bool | None = None,
+    lifecycle_status: list[str] | None = None,
+    stale_after_days: int | None = None,
     limit: int = 50,
     offset: int = 0,
 ) -> list[Node]:
-    stmt = select(Node).where(Node.team_id == team_id).order_by(Node.updated_at.desc())
+    stmt = (
+        select(Node)
+        .options(joinedload(Node.owner), joinedload(Node.reviewed_by))
+        .where(Node.team_id == team_id)
+        .order_by(Node.updated_at.desc())
+    )
     if parent_id is not None:
         stmt = stmt.where(Node.parent_node_id == parent_id)
     if q:
@@ -49,6 +64,11 @@ async def list_nodes(
         stmt = stmt.where(Node.parent_node_id.is_(None))
     elif is_orphan is False:
         stmt = stmt.where(Node.parent_node_id.isnot(None))
+    if lifecycle_status:
+        stmt = stmt.where(Node.lifecycle_status.in_(lifecycle_status))
+    if stale_after_days is not None:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=stale_after_days)
+        stmt = stmt.where(or_(Node.last_seen_at.is_(None), Node.last_seen_at < cutoff))
     stmt = stmt.limit(limit).offset(offset)
     res = await db.execute(stmt)
     return list(res.scalars().all())
@@ -168,7 +188,12 @@ async def get_node_stats(db: AsyncSession, *, team_id: uuid.UUID, top_tags_limit
 
 
 async def get_node(db: AsyncSession, *, team_id: uuid.UUID, node_id: uuid.UUID) -> Node | None:
-    res = await db.execute(select(Node).where(Node.team_id == team_id).where(Node.id == node_id))
+    res = await db.execute(
+        select(Node)
+        .options(joinedload(Node.owner), joinedload(Node.reviewed_by))
+        .where(Node.team_id == team_id)
+        .where(Node.id == node_id)
+    )
     return res.scalar_one_or_none()
 
 async def validate_parent_node_id(
@@ -265,3 +290,86 @@ async def bulk_update_tags(
     await db.flush()
     return len(nodes)
 
+
+def _stale_condition(cutoff: datetime):
+    return or_(Node.last_seen_at.is_(None), Node.last_seen_at < cutoff)
+
+
+def _review_due_condition(cutoff: datetime):
+    source_timestamp = func.coalesce(Node.last_seen_at, Node.created_at)
+    return or_(
+        Node.reviewed_at.is_(None),
+        Node.reviewed_at < source_timestamp,
+        Node.reviewed_at < cutoff,
+    )
+
+
+async def get_stale_review_queue(
+    db: AsyncSession,
+    *,
+    team_id: uuid.UUID,
+    stale_after_days: int,
+    limit: int = 200,
+) -> StaleReviewQueue:
+    cutoff = datetime.now(timezone.utc) - timedelta(days=stale_after_days)
+    stale = _stale_condition(cutoff)
+    due = _review_due_condition(cutoff)
+
+    pending_stmt = (
+        select(Node)
+        .options(joinedload(Node.owner), joinedload(Node.reviewed_by))
+        .where(Node.team_id == team_id)
+        .where(Node.lifecycle_status == "active")
+        .where(stale)
+        .where(due)
+        .order_by(Node.last_seen_at.asc().nullsfirst(), Node.name.asc())
+        .limit(limit)
+    )
+    pending_nodes = list((await db.execute(pending_stmt)).scalars().unique().all())
+
+    counts = await db.execute(
+        select(
+            func.count(Node.id).filter(
+                and_(Node.lifecycle_status == "active", stale, due)
+            ),
+            func.count(Node.id).filter(and_(Node.lifecycle_status == "ignored", stale)),
+            func.count(Node.id).filter(and_(Node.lifecycle_status == "retired", stale)),
+            func.count(Node.id).filter(stale),
+        ).where(Node.team_id == team_id)
+    )
+    pending, ignored, retired, total_stale = counts.one()
+    return StaleReviewQueue(
+        summary=StaleReviewSummary(
+            stale_after_days=stale_after_days,
+            pending=int(pending or 0),
+            ignored=int(ignored or 0),
+            retired=int(retired or 0),
+            total_stale=int(total_stale or 0),
+        ),
+        nodes=pending_nodes,
+    )
+
+
+async def apply_stale_review_decision(
+    db: AsyncSession,
+    *,
+    team_id: uuid.UUID,
+    node_ids: list[uuid.UUID],
+    lifecycle_status: str,
+    reviewed_by_id: uuid.UUID,
+    owner_user_id: uuid.UUID | None,
+) -> int:
+    values: dict = {
+        "lifecycle_status": lifecycle_status,
+        "reviewed_at": datetime.now(timezone.utc),
+        "reviewed_by_id": reviewed_by_id,
+    }
+    if owner_user_id is not None:
+        values["owner_user_id"] = owner_user_id
+    result = await db.execute(
+        update(Node)
+        .where(Node.team_id == team_id)
+        .where(Node.id.in_(node_ids))
+        .values(**values)
+    )
+    return result.rowcount  # type: ignore[return-value]

--- a/backend/app/services/refresh_sessions.py
+++ b/backend/app/services/refresh_sessions.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import hashlib
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from jwt import InvalidTokenError
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.security import create_refresh_token, decode_token
+from app.models.refresh_session import RefreshSession
+
+
+class RefreshSessionError(Exception):
+    def __init__(self, message: str, *, reuse_detected: bool = False) -> None:
+        super().__init__(message)
+        self.reuse_detected = reuse_detected
+
+
+def _token_hash(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _metadata(ip: str | None, user_agent: str | None) -> tuple[str | None, str | None]:
+    return (ip[:64] if ip else None, user_agent[:500] if user_agent else None)
+
+
+async def issue_refresh_session(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    ip: str | None,
+    user_agent: str | None,
+    family_id: uuid.UUID | None = None,
+) -> tuple[RefreshSession, str]:
+    now = datetime.now(UTC)
+    session_id = uuid.uuid4()
+    raw_token = create_refresh_token(user_id=user_id, session_id=session_id)
+    created_ip, stored_user_agent = _metadata(ip, user_agent)
+    session = RefreshSession(
+        id=session_id,
+        user_id=user_id,
+        family_id=family_id or session_id,
+        token_hash=_token_hash(raw_token),
+        expires_at=now + timedelta(days=settings.refresh_token_expires_days),
+        created_ip=created_ip,
+        user_agent=stored_user_agent,
+    )
+    db.add(session)
+    await db.flush()
+    return session, raw_token
+
+
+async def rotate_refresh_session(
+    db: AsyncSession,
+    *,
+    raw_token: str,
+    ip: str | None,
+    user_agent: str | None,
+) -> tuple[uuid.UUID, str]:
+    try:
+        payload = decode_token(raw_token)
+        if payload.get("typ") != "refresh":
+            raise RefreshSessionError("Invalid refresh token")
+        session_id = uuid.UUID(payload["jti"])
+        user_id = uuid.UUID(payload["sub"])
+    except (InvalidTokenError, KeyError, ValueError) as exc:
+        raise RefreshSessionError("Invalid refresh token") from exc
+
+    result = await db.execute(
+        select(RefreshSession)
+        .where(RefreshSession.id == session_id)
+        .with_for_update()
+    )
+    session = result.scalar_one_or_none()
+    if not session or session.user_id != user_id or session.token_hash != _token_hash(raw_token):
+        raise RefreshSessionError("Invalid refresh token")
+
+    now = datetime.now(UTC)
+    if session.expires_at <= now:
+        session.revoked_at = session.revoked_at or now
+        await db.flush()
+        raise RefreshSessionError("Refresh token expired")
+
+    if session.used_at or session.revoked_at or session.replaced_by_id:
+        await db.execute(
+            update(RefreshSession)
+            .where(RefreshSession.family_id == session.family_id)
+            .where(RefreshSession.revoked_at.is_(None))
+            .values(revoked_at=now)
+        )
+        await db.flush()
+        raise RefreshSessionError("Refresh token reuse detected", reuse_detected=True)
+
+    successor, new_token = await issue_refresh_session(
+        db,
+        user_id=user_id,
+        family_id=session.family_id,
+        ip=ip,
+        user_agent=user_agent,
+    )
+    session.used_at = now
+    session.revoked_at = now
+    session.replaced_by_id = successor.id
+    await db.flush()
+    return user_id, new_token
+
+
+async def revoke_refresh_family(db: AsyncSession, *, raw_token: str) -> None:
+    try:
+        payload = decode_token(raw_token)
+        session_id = uuid.UUID(payload["jti"])
+    except (InvalidTokenError, KeyError, ValueError):
+        return
+    result = await db.execute(select(RefreshSession.family_id).where(RefreshSession.id == session_id))
+    family_id = result.scalar_one_or_none()
+    if family_id is None:
+        return
+    await db.execute(
+        update(RefreshSession)
+        .where(RefreshSession.family_id == family_id)
+        .where(RefreshSession.revoked_at.is_(None))
+        .values(revoked_at=datetime.now(UTC))
+    )
+
+
+async def revoke_all_refresh_sessions(db: AsyncSession, *, user_id: uuid.UUID) -> None:
+    await db.execute(
+        update(RefreshSession)
+        .where(RefreshSession.user_id == user_id)
+        .where(RefreshSession.revoked_at.is_(None))
+        .values(revoked_at=datetime.now(UTC))
+    )

--- a/backend/app/services/refresh_sessions.py
+++ b/backend/app/services/refresh_sessions.py
@@ -20,6 +20,8 @@ class RefreshSessionError(Exception):
 
 
 def _token_hash(token: str) -> str:
+    # Refresh JWTs are signed, high-entropy opaque credentials, not passwords.
+    # codeql[py/weak-sensitive-data-hashing]
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
 
 

--- a/backend/app/services/registration_tokens.py
+++ b/backend/app/services/registration_tokens.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import secrets
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -10,8 +9,9 @@ from sqlalchemy.orm import joinedload
 
 from app.models.node import Node
 from app.models.registration_token import RegistrationToken
+from app.core.opaque_tokens import generate_opaque_token, hash_opaque_token
 
-TOKEN_BYTES = 32
+REGISTRATION_TOKEN_PREFIX = "nb_reg_"  # nosec B105
 
 
 def _merge_unique_strs(existing: list[str] | None, incoming: list[str] | None) -> list[str]:
@@ -54,8 +54,8 @@ async def create_registration_token(
     max_uses: int | None = None,
     allowed_kinds: list[str] | None = None,
     expires_in_days: int | None = None,
-) -> RegistrationToken:
-    token = secrets.token_urlsafe(TOKEN_BYTES)
+) -> tuple[RegistrationToken, str]:
+    token, token_hash, token_prefix = generate_opaque_token(prefix=REGISTRATION_TOKEN_PREFIX)
     expires_at = (
         datetime.now(timezone.utc) + timedelta(days=expires_in_days)
         if expires_in_days
@@ -64,7 +64,8 @@ async def create_registration_token(
     rt = RegistrationToken(
         team_id=team_id,
         label=label,
-        token=token,
+        token_hash=token_hash,
+        token_prefix=token_prefix,
         created_by_id=created_by_id,
         max_uses=max_uses,
         allowed_kinds=allowed_kinds,
@@ -72,7 +73,7 @@ async def create_registration_token(
     )
     db.add(rt)
     await db.flush()
-    return rt
+    return rt, token
 
 
 async def list_registration_tokens(
@@ -111,7 +112,7 @@ async def get_registration_token_by_value(
     res = await db.execute(
         select(RegistrationToken)
         .options(joinedload(RegistrationToken.team))
-        .where(RegistrationToken.token == token)
+        .where(RegistrationToken.token_hash == hash_opaque_token(token))
     )
     return res.scalar_one_or_none()
 
@@ -199,6 +200,9 @@ async def register_or_update_node_with_token(
         existing.updated_at = now
         existing.last_seen_at = now
         existing.last_seen_source = "register-node"
+        existing.lifecycle_status = "active"
+        existing.reviewed_at = None
+        existing.reviewed_by_id = None
         await db.flush()
         return existing, False
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ uvicorn[standard]>=0.34.0,<1.0
 
 SQLAlchemy[asyncio]>=2.0.48,<2.1
 asyncpg>=0.30.0,<1.0
+redis>=5.2.0,<7.0
 alembic>=1.14.1,<2.0
 
 pydantic>=2.10.6,<3.0
@@ -16,4 +17,3 @@ python-multipart>=0.0.20,<1.0
 
 pytest>=9.0.3,<10.0
 httpx>=0.28.1,<0.29.1
-

--- a/backend/tests/test_opaque_tokens.py
+++ b/backend/tests/test_opaque_tokens.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from app.core.opaque_tokens import generate_opaque_token, hash_opaque_token
+
+
+def test_opaque_tokens_are_prefixed_unique_and_hash_only() -> None:
+    first, first_hash, first_prefix = generate_opaque_token(prefix="nb_inv_")
+    second, second_hash, _ = generate_opaque_token(prefix="nb_inv_")
+
+    assert first.startswith("nb_inv_")
+    assert len(first) >= 48
+    assert first != second
+    assert first_hash != second_hash
+    assert first_hash == hash_opaque_token(first)
+    assert first not in first_hash
+    assert first_prefix == first[:16]

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,23 +1,55 @@
 from __future__ import annotations
 
+import asyncio
+from collections import defaultdict
+
 import pytest
 from fastapi import HTTPException
+from redis.exceptions import ConnectionError
 
-from app.core.rate_limit import _RateLimiter
+from app.core.rate_limit import _RedisRateLimiter
+
+
+class FakeRedis:
+    def __init__(self) -> None:
+        self.counts: dict[str, int] = defaultdict(int)
+
+    async def eval(self, _script: str, _num_keys: int, key: str, *_args: object) -> int:
+        self.counts[key] += 1
+        return self.counts[key]
+
+
+class BrokenRedis:
+    async def eval(self, *_args: object) -> int:
+        raise ConnectionError("redis unavailable")
 
 
 def test_rate_limiter_rejects_request_over_budget() -> None:
-    limiter = _RateLimiter()
-    limiter.check("client", max_hits=2, window_seconds=60)
-    limiter.check("client", max_hits=2, window_seconds=60)
+    async def scenario() -> None:
+        limiter = _RedisRateLimiter(FakeRedis())  # type: ignore[arg-type]
+        await limiter.check("client", max_hits=2, window_seconds=60)
+        await limiter.check("client", max_hits=2, window_seconds=60)
+        with pytest.raises(HTTPException) as exc:
+            await limiter.check("client", max_hits=2, window_seconds=60)
+        assert exc.value.status_code == 429
 
-    with pytest.raises(HTTPException) as exc:
-        limiter.check("client", max_hits=2, window_seconds=60)
-
-    assert exc.value.status_code == 429
+    asyncio.run(scenario())
 
 
 def test_rate_limiter_keeps_budgets_isolated() -> None:
-    limiter = _RateLimiter()
-    limiter.check("client-a", max_hits=1, window_seconds=60)
-    limiter.check("client-b", max_hits=1, window_seconds=60)
+    async def scenario() -> None:
+        limiter = _RedisRateLimiter(FakeRedis())  # type: ignore[arg-type]
+        await limiter.check("client-a", max_hits=1, window_seconds=60)
+        await limiter.check("client-b", max_hits=1, window_seconds=60)
+
+    asyncio.run(scenario())
+
+
+def test_rate_limiter_fails_closed_when_redis_is_unavailable() -> None:
+    async def scenario() -> None:
+        limiter = _RedisRateLimiter(BrokenRedis())  # type: ignore[arg-type]
+        with pytest.raises(HTTPException) as exc:
+            await limiter.check("client", max_hits=1, window_seconds=60)
+        assert exc.value.status_code == 503
+
+    asyncio.run(scenario())

--- a/backend/tests/test_security_regressions.py
+++ b/backend/tests/test_security_regressions.py
@@ -21,3 +21,23 @@ def test_ci_does_not_mask_backend_test_failures() -> None:
     workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text()
 
     assert "pytest tests/ -v --tb=short || true" not in workflow
+
+
+def test_codeql_scans_python_and_typescript() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "codeql.yml").read_text()
+
+    assert "javascript-typescript" in workflow
+    assert "python" in workflow
+    assert "security-extended" in workflow
+
+
+def test_plaintext_invite_and_registration_token_columns_are_gone() -> None:
+    invite_model = (ROOT / "backend" / "app" / "models" / "invite.py").read_text()
+    registration_model = (
+        ROOT / "backend" / "app" / "models" / "registration_token.py"
+    ).read_text()
+
+    assert "token_hash" in invite_model
+    assert "token_hash" in registration_model
+    assert " token:" not in invite_model
+    assert " token:" not in registration_model

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,4 +1,16 @@
 services:
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    security_opt:
+      - no-new-privileges:true
+
   db:
     image: postgres:16
     restart: unless-stopped
@@ -24,6 +36,7 @@ services:
     init: true
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-nodebyte}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-nodebyte}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
       FRONTEND_ORIGIN: ${FRONTEND_ORIGIN:?FRONTEND_ORIGIN must be set}
       PYTHONPATH: /app
       NODEBYTE_ENV: production
@@ -38,6 +51,8 @@ services:
       TURNSTILE_ENABLED: ${TURNSTILE_ENABLED:-true}
     depends_on:
       db:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     ports:
       - "8000:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,13 @@
 services:
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+
   db:
     image: postgres:16
     restart: unless-stopped
@@ -24,6 +33,7 @@ services:
     environment:
       # Override localhost DB URL for container networking
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-nodebyte}:${POSTGRES_PASSWORD:-devpassword}@db:5432/${POSTGRES_DB:-nodebyte}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
       FRONTEND_ORIGIN: ${FRONTEND_ORIGIN:-http://localhost:3000}
       PYTHONPATH: /app
       NODEBYTE_ENV: ${NODEBYTE_ENV:-dev}
@@ -38,6 +48,8 @@ services:
       TURNSTILE_ENABLED: ${TURNSTILE_ENABLED:-true}
     depends_on:
       db:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     ports:
       - "8000:8000"
@@ -65,4 +77,3 @@ services:
 volumes:
   nodebyte_postgres:
   nodebyte_frontend_node_modules:
-

--- a/docs/SECURITY_HARDENING_PHASE_2_2026-08-12.md
+++ b/docs/SECURITY_HARDENING_PHASE_2_2026-08-12.md
@@ -1,0 +1,81 @@
+# Nodebyte security hardening phase 2 — 2026-08-12
+
+## Outcome
+
+This release closes every explicitly deferred item from the first review and ships the
+recommended stale-inventory workflow:
+
+- Redis-backed, fail-closed sliding-window limits shared by all backend replicas.
+- Stateful refresh-session rotation, logout/password/admin revocation, and refresh-token
+  reuse detection that revokes the full session family.
+- Show-once invite and registration secrets with SHA-256 lookup hashes at rest.
+- A stale-inventory review queue with configurable age, bulk keep/ignore/retire actions,
+  optional team-member ownership, reviewer attribution, and automatic reactivation when
+  an agent checks in again.
+- Per-request nonce-based production CSP. All application pages render dynamically so
+  Next.js applies the nonce to framework and inline scripts. Production script policy no
+  longer needs `unsafe-inline` or `unsafe-eval`; inline styles remain allowed for the
+  current Tailwind/Next.js stack.
+- Clean React/ESLint output with the six prior warnings fixed rather than suppressed.
+- GitHub CodeQL scanning for Python and JavaScript/TypeScript on pull requests, pushes to
+  `master`, and a weekly schedule using the extended security query suite.
+
+## Data migration
+
+Alembic revision `0006_security_sessions`:
+
+1. Creates `refresh_sessions` with session family, token hash, rotation, revocation, IP,
+   and user-agent metadata.
+2. Hashes every existing invite and registration token in the same transaction, stores
+   an identifying prefix, and removes the plaintext columns. Existing links remain valid.
+3. Adds node lifecycle, review, and owner fields with team/status and last-seen indexes.
+
+The migration is one-way with respect to secret recovery: a downgrade can restore the
+old schema shape but cannot recover plaintext from a secure hash. Take a database backup
+before deployment.
+
+## Runtime contract
+
+- Redis is required. Authentication and node-registration endpoints return 503 if the
+  shared limiter cannot enforce a budget; they do not silently fail open.
+- Redis holds ephemeral limiter state only. PostgreSQL remains the system of record.
+- Registration and invite secrets are returned only by their create response. List
+  responses expose `token_prefix`, never the credential.
+- Refresh-token rotation accepts each token once. Reuse returns 401 and invalidates the
+  replacement token and all other sessions in that family.
+- Active nodes become due for review when never seen or older than the selected threshold.
+  An active decision defers the item for one threshold interval. Ignored and retired
+  nodes are excluded from the default inventory view. A registration update restores a
+  node to active and clears its prior review marker.
+
+## Verification record
+
+- Backend unit/regression suite: 11 passed.
+- PostgreSQL migration from `0005_api_tokens` with existing plaintext test records:
+  hashes matched, raw columns were absent, old lookup values remained usable, and the
+  lifecycle default was active.
+- Two independent backend processes sharing Redis: requests 1–30 reached application
+  authentication; request 31 was globally rejected with 429.
+- Refresh flow: initial rotation succeeded; replay returned the reuse-specific 401; the
+  successor then returned 401 because its family had been revoked.
+- Stale workflow: a 45-day-old registered node appeared in the 30-day queue, accepted an
+  ignored decision, and returned to active after the same agent hostname checked in.
+- Invite/registration workflow: create responses contained a one-time secret, list
+  responses did not, database hashes matched, and submitted secrets still resolved.
+- Frontend ESLint and production build passed. Runtime HTML had a matching CSP nonce on
+  all 12 script elements, with `strict-dynamic`, `frame-ancestors 'none'`, and no
+  production `unsafe-inline`/`unsafe-eval` script allowance.
+
+## Operational checks
+
+```bash
+docker compose -f docker-compose.prod.yml config --quiet
+docker compose -f docker-compose.prod.yml build
+docker compose -f docker-compose.prod.yml up -d --wait --remove-orphans
+docker compose -f docker-compose.prod.yml ps
+```
+
+After rollout, confirm that `backend`, `frontend`, `db`, and `redis` are healthy; Redis
+has no published port; `alembic_version` is `0006_security_sessions`; public health is
+200; production CSP contains a fresh nonce on separate requests; and CodeQL completes
+for both configured languages.

--- a/env.example
+++ b/env.example
@@ -6,6 +6,9 @@ POSTGRES_USER=nodebyte
 POSTGRES_PASSWORD=changeme
 POSTGRES_PORT=5432
 
+# Redis (shared rate limits across backend replicas)
+REDIS_URL=redis://redis:6379/0
+
 # Backend
 NODEBYTE_ENV=dev
 JWT_SECRET=changeme-generate-a-random-string

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -3,15 +3,6 @@ import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
 
 const eslintConfig = defineConfig([
   ...nextCoreWebVitals,
-  {
-    rules: {
-      // These rules are new in eslint-config-next 16 (react-hooks v6) and
-      // flag pre-existing patterns. Downgraded to warnings so CI stays green;
-      // fix the underlying code and re-promote to errors when possible.
-      "react-hooks/set-state-in-effect": "warn",
-      "react-hooks/refs": "warn",
-    },
-  },
   globalIgnores([".next/**", "out/**", "build/**", "next-env.d.ts"]),
 ]);
 

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -22,11 +22,6 @@ const nextConfig = {
             key: "Permissions-Policy",
             value: "camera=(), microphone=(), geolocation=()",
           },
-          {
-            key: "Content-Security-Policy",
-            value:
-              "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-src https://challenges.cloudflare.com; object-src 'none'; base-uri 'self';",
-          },
         ],
       },
     ];

--- a/frontend/src/app/dashboard/admin/teams/page.tsx
+++ b/frontend/src/app/dashboard/admin/teams/page.tsx
@@ -34,7 +34,10 @@ export default function AdminTeamsPage() {
       .finally(() => setLoading(false));
   }, [debouncedSearch]);
 
-  useEffect(() => { load(); }, [load]);
+  useEffect(() => {
+    const timer = window.setTimeout(load, 0);
+    return () => window.clearTimeout(timer);
+  }, [load]);
 
   function openCreate() {
     setDialogMode("create");

--- a/frontend/src/app/dashboard/admin/users/page.tsx
+++ b/frontend/src/app/dashboard/admin/users/page.tsx
@@ -38,7 +38,10 @@ export default function AdminUsersPage() {
       .finally(() => setLoading(false));
   }, [debouncedSearch]);
 
-  useEffect(() => { load(); }, [load]);
+  useEffect(() => {
+    const timer = window.setTimeout(load, 0);
+    return () => window.clearTimeout(timer);
+  }, [load]);
 
   useEffect(() => {
     if (!actionMenu) return;

--- a/frontend/src/app/dashboard/layout.tsx
+++ b/frontend/src/app/dashboard/layout.tsx
@@ -18,6 +18,7 @@ import {
   Shield,
   UsersRound,
   Building2,
+  Archive,
 } from "lucide-react";
 
 import { useAuth } from "@/lib/auth";
@@ -27,7 +28,8 @@ import { CreateTeamDialog } from "@/components/create-team-dialog";
 
 const NAV_ITEMS: readonly { href: string; label: string; icon: typeof LayoutDashboard; exact?: boolean; muted?: boolean }[] = [
   { href: "/dashboard", label: "Overview", icon: LayoutDashboard, exact: true },
-  { href: "/dashboard/nodes", label: "Nodes", icon: Server },
+  { href: "/dashboard/nodes", label: "Nodes", icon: Server, exact: true },
+  { href: "/dashboard/nodes/review", label: "Stale review", icon: Archive },
   { href: "/dashboard/team", label: "Team", icon: Users },
   { href: "/dashboard/tokens", label: "Tokens", icon: KeyRound },
   { href: "/dashboard/settings", label: "Settings", icon: Settings },
@@ -52,10 +54,6 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
       router.replace("/login");
     }
   }, [loading, user, router]);
-
-  useEffect(() => {
-    setMobileMenuOpen(false);
-  }, [pathname]);
 
   if (loading) {
     return (
@@ -114,7 +112,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   const navLinks = (
     <nav className="flex-1 space-y-1 p-3">
       {NAV_ITEMS.map(({ href, label, icon: Icon, exact, muted }) => (
-        <Link key={href} href={href} className={navLinkClass(href, exact, muted)}>
+        <Link key={href} href={href} onClick={() => setMobileMenuOpen(false)} className={navLinkClass(href, exact, muted)}>
           <Icon className="h-4 w-4" />
           {label}
         </Link>
@@ -126,7 +124,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
             Admin
           </div>
           {ADMIN_NAV_ITEMS.map(({ href, label, icon: Icon, exact }) => (
-            <Link key={href} href={href} className={navLinkClass(href, exact)}>
+            <Link key={href} href={href} onClick={() => setMobileMenuOpen(false)} className={navLinkClass(href, exact)}>
               <Icon className="h-4 w-4" />
               {label}
             </Link>

--- a/frontend/src/app/dashboard/nodes/page.tsx
+++ b/frontend/src/app/dashboard/nodes/page.tsx
@@ -45,6 +45,7 @@ export default function NodesPage() {
         has_url: filters.hasUrl ?? undefined,
         tags: filters.tags.length > 0 ? filters.tags : undefined,
         is_orphan: filters.isOrphan ?? undefined,
+        lifecycle_status: ["active"],
       });
       setNodes(data);
     } catch {

--- a/frontend/src/app/dashboard/nodes/review/page.tsx
+++ b/frontend/src/app/dashboard/nodes/review/page.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Archive, CheckCircle2, EyeOff, RefreshCw } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
+import { api, ApiError, type MemberPublic, type StaleReviewQueue } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+
+
+function canReview(role: string | null | undefined) {
+  return role === "owner" || role === "admin" || role === "member";
+}
+
+
+function lastSeenLabel(value: string | null) {
+  if (!value) return "Never seen";
+  const days = Math.max(0, Math.floor((Date.now() - new Date(value).getTime()) / 86_400_000));
+  return days === 0 ? "Seen today" : `${days} day${days === 1 ? "" : "s"} ago`;
+}
+
+
+export default function StaleInventoryReviewPage() {
+  const { activeTeam } = useAuth();
+  const [threshold, setThreshold] = useState(30);
+  const [queue, setQueue] = useState<StaleReviewQueue | null>(null);
+  const [members, setMembers] = useState<MemberPublic[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [ownerUserId, setOwnerUserId] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const allowed = canReview(activeTeam?.my_role);
+
+  const load = useCallback(async () => {
+    if (!activeTeam) return;
+    setLoading(true);
+    setError("");
+    try {
+      const [reviewQueue, teamMembers] = await Promise.all([
+        api.nodes.staleReview(activeTeam.id, threshold),
+        api.members.list(activeTeam.id),
+      ]);
+      setQueue(reviewQueue);
+      setMembers(teamMembers);
+      setSelected(new Set());
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Could not load stale inventory");
+    } finally {
+      setLoading(false);
+    }
+  }, [activeTeam, threshold]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(load, 0);
+    return () => window.clearTimeout(timer);
+  }, [load]);
+
+  const allSelected = useMemo(
+    () => Boolean(queue?.nodes.length) && selected.size === queue?.nodes.length,
+    [queue, selected]
+  );
+
+  function toggleNode(id: string) {
+    setSelected((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  async function decide(status: "active" | "ignored" | "retired") {
+    if (!activeTeam || selected.size === 0) return;
+    setBusy(true);
+    setError("");
+    try {
+      await api.nodes.decideStaleReview(activeTeam.id, {
+        node_ids: [...selected],
+        lifecycle_status: status,
+        owner_user_id: ownerUserId || undefined,
+      });
+      await load();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Could not save review decision");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Stale inventory review</h1>
+          <p className="text-sm text-[hsl(var(--muted-foreground))]">
+            Decide whether inactive nodes should remain active, be ignored, or be retired.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <label className="text-sm" htmlFor="stale-threshold">Stale after</label>
+          <select
+            id="stale-threshold"
+            value={threshold}
+            onChange={(event) => setThreshold(Number(event.target.value))}
+            className="h-9 rounded-md border border-[hsl(var(--border))] bg-transparent px-3 text-sm"
+          >
+            <option value={7}>7 days</option>
+            <option value={30}>30 days</option>
+            <option value={60}>60 days</option>
+            <option value={90}>90 days</option>
+          </select>
+          <Button variant="outline" size="sm" onClick={load} disabled={loading}>
+            <RefreshCw className="mr-1.5 h-4 w-4" /> Refresh
+          </Button>
+        </div>
+      </div>
+
+      {queue && (
+        <div className="grid gap-3 sm:grid-cols-4">
+          {[
+            ["Needs review", queue.summary.pending],
+            ["All stale", queue.summary.total_stale],
+            ["Ignored", queue.summary.ignored],
+            ["Retired", queue.summary.retired],
+          ].map(([label, value]) => (
+            <Card key={label}>
+              <CardContent className="pt-5">
+                <div className="text-2xl font-semibold">{value}</div>
+                <div className="text-xs text-[hsl(var(--muted-foreground))]">{label}</div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {error && <div className="rounded-md bg-red-50 p-3 text-sm text-red-700 dark:bg-red-950 dark:text-red-300">{error}</div>}
+
+      {selected.size > 0 && allowed && (
+        <div className="flex flex-wrap items-center gap-2 rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--muted))] p-3">
+          <span className="text-sm font-medium">{selected.size} selected</span>
+          <select
+            value={ownerUserId}
+            onChange={(event) => setOwnerUserId(event.target.value)}
+            className="h-9 rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--background))] px-3 text-sm"
+          >
+            <option value="">Keep current owner</option>
+            {members.map((member) => (
+              <option key={member.user_id} value={member.user_id}>{member.full_name || member.email}</option>
+            ))}
+          </select>
+          <Button size="sm" variant="outline" disabled={busy} onClick={() => decide("active")}>
+            <CheckCircle2 className="mr-1.5 h-4 w-4" /> Keep active
+          </Button>
+          <Button size="sm" variant="outline" disabled={busy} onClick={() => decide("ignored")}>
+            <EyeOff className="mr-1.5 h-4 w-4" /> Ignore
+          </Button>
+          <Button size="sm" disabled={busy} onClick={() => decide("retired")} className="bg-red-600 text-white hover:bg-red-700">
+            <Archive className="mr-1.5 h-4 w-4" /> Retire
+          </Button>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex justify-center py-16"><Spinner className="h-6 w-6" /></div>
+      ) : !queue?.nodes.length ? (
+        <div className="rounded-xl border border-dashed border-[hsl(var(--border))] py-16 text-center">
+          <CheckCircle2 className="mx-auto mb-3 h-8 w-8 text-green-600" />
+          <p className="font-medium">The stale review queue is clear.</p>
+          <p className="text-sm text-[hsl(var(--muted-foreground))]">Reviewed nodes return only after another stale interval or a new activity cycle.</p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-[hsl(var(--border))]">
+          <table className="w-full min-w-[720px] text-sm">
+            <thead className="bg-[hsl(var(--muted))]">
+              <tr>
+                <th className="px-4 py-3 text-left">
+                  <input
+                    type="checkbox"
+                    aria-label="Select all stale nodes"
+                    checked={allSelected}
+                    onChange={() => setSelected(allSelected ? new Set() : new Set(queue.nodes.map((node) => node.id)))}
+                  />
+                </th>
+                <th className="px-4 py-3 text-left font-medium">Node</th>
+                <th className="px-4 py-3 text-left font-medium">Kind</th>
+                <th className="px-4 py-3 text-left font-medium">Last seen</th>
+                <th className="px-4 py-3 text-left font-medium">Source</th>
+                <th className="px-4 py-3 text-left font-medium">Owner</th>
+              </tr>
+            </thead>
+            <tbody>
+              {queue.nodes.map((node) => (
+                <tr key={node.id} className="border-t border-[hsl(var(--border))]">
+                  <td className="px-4 py-3">
+                    <input
+                      type="checkbox"
+                      aria-label={`Select ${node.name}`}
+                      checked={selected.has(node.id)}
+                      onChange={() => toggleNode(node.id)}
+                    />
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="font-medium">{node.name}</div>
+                    <div className="text-xs text-[hsl(var(--muted-foreground))]">{node.hostname || node.ip || "No hostname"}</div>
+                  </td>
+                  <td className="px-4 py-3"><Badge variant="outline">{node.kind}</Badge></td>
+                  <td className="px-4 py-3 font-medium text-amber-700 dark:text-amber-300">{lastSeenLabel(node.last_seen_at)}</td>
+                  <td className="px-4 py-3 text-[hsl(var(--muted-foreground))]">{node.last_seen_source || "—"}</td>
+                  <td className="px-4 py-3 text-[hsl(var(--muted-foreground))]">{node.owner_email || "Unassigned"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/dashboard/tokens/page.tsx
+++ b/frontend/src/app/dashboard/tokens/page.tsx
@@ -227,7 +227,7 @@ export default function RegistrationTokensPage() {
                   <td className="px-4 py-3">
                     <div className="font-medium">{rt.label}</div>
                     <div className="mt-0.5 font-mono text-xs text-[hsl(var(--muted-foreground))]">
-                      {rt.token.slice(0, 12)}...
+                      {rt.token_prefix}…
                     </div>
                   </td>
                   <td className="hidden px-4 py-3 sm:table-cell">
@@ -265,7 +265,6 @@ export default function RegistrationTokensPage() {
                   </td>
                   <td className="px-4 py-3 text-right">
                     <div className="flex items-center justify-end gap-1">
-                      <CopyTokenButton token={rt.token} />
                       {rt.is_active && (
                         <Button variant="ghost" size="sm" onClick={() => handleRevoke(rt)} className="text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950">
                           <Ban className="h-3.5 w-3.5" />

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import { connection } from "next/server";
 
 import { AuthProvider } from "@/lib/auth";
 import "./globals.css";
@@ -11,7 +12,10 @@ export const metadata: Metadata = {
   description: "Modern inventory for devices and sites.",
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  // Nonce-based CSP requires request-time rendering so Next can apply the
+  // per-request nonce to every framework and inline script.
+  await connection();
   return (
     <html lang="en">
       <body className={inter.className}>

--- a/frontend/src/components/node-detail-dialog.tsx
+++ b/frontend/src/components/node-detail-dialog.tsx
@@ -362,7 +362,7 @@ export function NodeDetailDialog({ open, onOpenChange, node, onEdit }: NodeDetai
 
     loadRelations();
     return () => { cancelled = true; };
-  }, [open, node?.id, node?.team_id, node?.parent_node_id]);
+  }, [open, node]);
 
   if (!open || !node) return null;
 

--- a/frontend/src/components/turnstile.tsx
+++ b/frontend/src/components/turnstile.tsx
@@ -55,8 +55,10 @@ export function Turnstile({ siteKey, onVerify, onExpire, className }: TurnstileP
   const onVerifyRef = useRef(onVerify);
   const onExpireRef = useRef(onExpire);
 
-  onVerifyRef.current = onVerify;
-  onExpireRef.current = onExpire;
+  useEffect(() => {
+    onVerifyRef.current = onVerify;
+    onExpireRef.current = onExpire;
+  }, [onVerify, onExpire]);
 
   const key = siteKey || process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || "";
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -93,10 +93,14 @@ export interface InvitePublic {
   team_id: string;
   invited_email: string;
   role: string;
-  token: string;
+  token_prefix: string;
   invited_by_email: string | null;
   created_at: string;
   expires_at: string;
+}
+
+export interface InviteCreated extends InvitePublic {
+  token: string;
 }
 
 export interface InviteInfo {
@@ -114,7 +118,7 @@ export interface RegistrationTokenPublic {
   id: string;
   team_id: string;
   label: string;
-  token: string;
+  token_prefix: string;
   created_by_email: string | null;
   max_uses: number | null;
   use_count: number;
@@ -123,6 +127,10 @@ export interface RegistrationTokenPublic {
   is_active: boolean;
   is_usable: boolean;
   created_at: string;
+}
+
+export interface RegistrationTokenCreated extends RegistrationTokenPublic {
+  token: string;
 }
 
 export interface NodePublic {
@@ -139,6 +147,12 @@ export interface NodePublic {
   notes: string | null;
   last_seen_at: string | null;
   last_seen_source: string | null;
+  lifecycle_status: "active" | "ignored" | "retired";
+  reviewed_at: string | null;
+  reviewed_by_id: string | null;
+  reviewed_by_email: string | null;
+  owner_user_id: string | null;
+  owner_email: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -162,6 +176,19 @@ export interface NodeStats {
   top_tags: TagCount[];
   ip_segments: { segment: string; node_count: number; address_count: number }[];
   ip_family_nodes: Record<string, number>;
+}
+
+export interface StaleReviewSummary {
+  stale_after_days: number;
+  pending: number;
+  ignored: number;
+  retired: number;
+  total_stale: number;
+}
+
+export interface StaleReviewQueue {
+  summary: StaleReviewSummary;
+  nodes: NodePublic[];
 }
 
 export interface PublicSettings {
@@ -277,7 +304,7 @@ export const api = {
       return request<InvitePublic[]>(`/api/teams/${teamId}/invites`);
     },
     create(teamId: string, data: { email: string; role: string }) {
-      return request<InvitePublic>(`/api/teams/${teamId}/invites`, {
+      return request<InviteCreated>(`/api/teams/${teamId}/invites`, {
         method: "POST",
         body: JSON.stringify(data),
       });
@@ -299,7 +326,7 @@ export const api = {
       return request<RegistrationTokenPublic[]>(`/api/teams/${teamId}/registration-tokens`);
     },
     create(teamId: string, data: { label: string; max_uses?: number | null; allowed_kinds?: string[] | null; expires_in_days?: number | null }) {
-      return request<RegistrationTokenPublic>(`/api/teams/${teamId}/registration-tokens`, {
+      return request<RegistrationTokenCreated>(`/api/teams/${teamId}/registration-tokens`, {
         method: "POST",
         body: JSON.stringify(data),
       });
@@ -315,7 +342,7 @@ export const api = {
     stats(teamId: string) {
       return request<NodeStats>(`/api/teams/${teamId}/nodes/stats`);
     },
-    list(teamId: string, params?: { q?: string; parent_id?: string; limit?: number; offset?: number; kind?: string[]; has_url?: boolean; tags?: string[]; is_orphan?: boolean }) {
+    list(teamId: string, params?: { q?: string; parent_id?: string; limit?: number; offset?: number; kind?: string[]; has_url?: boolean; tags?: string[]; is_orphan?: boolean; lifecycle_status?: string[]; stale_after_days?: number }) {
       const qs = new URLSearchParams();
       if (params?.q) qs.set("q", params.q);
       if (params?.parent_id) qs.set("parent_id", params.parent_id);
@@ -325,6 +352,8 @@ export const api = {
       if (params?.has_url !== undefined && params.has_url !== null) qs.set("has_url", String(params.has_url));
       if (params?.tags?.length) for (const t of params.tags) qs.append("tags", t);
       if (params?.is_orphan !== undefined && params.is_orphan !== null) qs.set("is_orphan", String(params.is_orphan));
+      if (params?.lifecycle_status?.length) for (const s of params.lifecycle_status) qs.append("lifecycle_status", s);
+      if (params?.stale_after_days) qs.set("stale_after_days", String(params.stale_after_days));
       const q = qs.toString();
       return request<NodePublic[]>(`/api/teams/${teamId}/nodes${q ? `?${q}` : ""}`);
     },
@@ -339,6 +368,20 @@ export const api = {
     },
     delete(teamId: string, nodeId: string) {
       return request<void>(`/api/teams/${teamId}/nodes/${nodeId}`, { method: "DELETE" });
+    },
+    staleReview(teamId: string, staleAfterDays = 30) {
+      return request<StaleReviewQueue>(
+        `/api/teams/${teamId}/nodes/stale-review?stale_after_days=${staleAfterDays}`
+      );
+    },
+    decideStaleReview(
+      teamId: string,
+      data: { node_ids: string[]; lifecycle_status: "active" | "ignored" | "retired"; owner_user_id?: string | null }
+    ) {
+      return request<{ affected: number }>(`/api/teams/${teamId}/nodes/stale-review/decide`, {
+        method: "POST",
+        body: JSON.stringify(data),
+      });
     },
     bulkDelete(teamId: string, nodeIds: string[]) {
       return request<{ affected: number }>(`/api/teams/${teamId}/nodes/bulk-delete`, {

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -1,0 +1,46 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+
+export function proxy(request: NextRequest) {
+  const nonce = btoa(crypto.randomUUID());
+  const developmentEval = process.env.NODE_ENV === "development" ? " 'unsafe-eval'" : "";
+  const upgrade = process.env.NODE_ENV === "development" ? "" : " upgrade-insecure-requests;";
+  const csp = [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${developmentEval} https://challenges.cloudflare.com`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self'",
+    "connect-src 'self' https://challenges.cloudflare.com",
+    "frame-src https://challenges.cloudflare.com",
+    "worker-src 'self' blob:",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    upgrade,
+  ].filter(Boolean).join("; ").replace(/\s{2,}/g, " ").trim();
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+  requestHeaders.set("Content-Security-Policy", csp);
+
+  const response = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
+  response.headers.set("Content-Security-Policy", csp);
+  return response;
+}
+
+
+export const config = {
+  matcher: [
+    {
+      source: "/((?!api|_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+      missing: [
+        { type: "header", key: "next-router-prefetch" },
+        { type: "header", key: "purpose", value: "prefetch" },
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
## What changed

- move login, registration, and node-registration rate limits to shared Redis
- add server-side refresh-session rotation, revocation, and reuse detection
- hash invite and registration credentials at rest and show plaintext only once
- add the stale-inventory review queue with ownership and keep/ignore/retire actions
- replace the permissive script CSP with per-request Next.js nonces
- fix all six existing React lint warnings and enable Python/TypeScript CodeQL
- add the Alembic data migration, Compose Redis service, regression tests, and operations documentation

## Why

These were the explicit residual security items from the 2026-08-12 review. The stale-inventory workflow is the highest-value product follow-up because Nodebyte already records last-seen state but did not give operators a safe way to act on it.

## Impact

Redis is now required for protected endpoints and is intentionally fail-closed. Existing invite and registration links continue to work after migration, but their plaintext values can no longer be recovered from the database. Existing refresh tokens issued before this release become invalid because they have no server-side session record.

## Validation

- backend: 11 tests passed; Python compile/import checks passed
- migration: upgraded a PostgreSQL database from `0005_api_tokens` with existing invite, registration, and stale-node records
- auth: rotation succeeded, replay revoked the full family, successor and inactive-user refreshes returned 401
- rate limits: two backend processes sharing Redis jointly returned 429 on request 31
- token storage: create returned plaintext once; lists omitted it; stored hashes matched submitted values
- stale workflow: queue, ownership, ignore, reactivation, and owned-node serialization passed end to end
- frontend: ESLint clean; Next.js production build passed; all 12 runtime scripts carried the CSP nonce
- audits: npm audit, backend and MCP pip-audit, Bandit, Gitleaks history/change scan, Compose validation, and actionlint passed

Plane: `8cedd739-542e-45b2-a75f-0918ec12876d`
