### PR TITLE
Add inventory accountability workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ A modern digital inventory manager built for IT teams. Track every device, site,
 - **Bookmark sync** — nodes with URLs automatically sync to browser bookmarks, organized by kind
 - **Bulk operations** — multi-select nodes to delete or tag in batch
 - **Stale inventory review** — triage inactive nodes in bulk, assign an owner, and keep, ignore, or retire them
+- **Import reconciliation** — preview authoritative Docker, Kubernetes, and LXD changes before applying, with explicit missing-node retirement
+- **Automation health** — see source freshness, failures, summaries, and sync-run history
+- **Audit history** — inspect append-only human and automation changes with before/after context
 - **Invite system** — invite team members by email with role-based access
 - **Super admin console** — platform-wide user and team management for superusers
 
@@ -188,6 +191,27 @@ This creates `frontend/public/downloads/extension.tar.gz` and an `extension-meta
 4. Click the Nodebyte icon in your toolbar, open **Settings**, and set your API URL
 
 The extension connects directly to the backend API (e.g. `http://localhost:8000`).
+
+## Authoritative inventory sync
+
+The Docker, Kubernetes, and LXD collectors now create a server-side preview before
+they apply changes. Each source owns only the records it has previously synchronized,
+so one source cannot retire another source's inventory.
+
+```bash
+# Preview only; no node mutation
+NODEBYTE_SYNC_MODE=preview ./scripts/docker-inventory.sh
+
+# Preview and apply creates/updates; missing nodes stay unchanged
+NODEBYTE_SYNC_MODE=apply ./scripts/docker-inventory.sh
+
+# Explicitly retire records missing from this authoritative snapshot
+NODEBYTE_SYNC_MODE=apply NODEBYTE_RETIRE_MISSING=1 ./scripts/docker-inventory.sh
+```
+
+Pending previews can also be reviewed under **Dashboard → Automation** and applied
+by a team owner or admin. The same page shows source health and recent run summaries.
+Every applied mutation is recorded under **Dashboard → Activity**.
 
 ## Personal API Tokens and MCP
 

--- a/backend/alembic/versions/0007_inventory_accountability.py
+++ b/backend/alembic/versions/0007_inventory_accountability.py
@@ -1,0 +1,118 @@
+"""inventory accountability, reconciliation, and automation health
+
+Revision ID: 0007_inventory_accountability
+Revises: 0006_security_sessions
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0007_inventory_accountability"
+down_revision = "0006_security_sessions"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "inventory_sources",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("team_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("registration_token_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("created_by_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("source_key", sa.String(length=160), nullable=False),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("source_type", sa.String(length=40), nullable=False),
+        sa.Column("expected_interval_minutes", sa.Integer(), server_default="1440", nullable=False),
+        sa.Column("last_attempt_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_success_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_failure_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("last_summary", postgresql.JSONB(), server_default=sa.text("'{}'::jsonb"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["team_id"], ["teams.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["registration_token_id"], ["registration_tokens.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["created_by_id"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("team_id", "source_key", name="uq_inventory_sources_team_key"),
+    )
+    op.create_index("ix_inventory_sources_team_id", "inventory_sources", ["team_id"])
+
+    op.create_table(
+        "inventory_sync_runs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("team_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("source_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("registration_token_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("reconcile_missing", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column("proposed_nodes", postgresql.JSONB(), nullable=False),
+        sa.Column("changes", postgresql.JSONB(), nullable=False),
+        sa.Column("summary", postgresql.JSONB(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("applied_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["team_id"], ["teams.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["source_id"], ["inventory_sources.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["registration_token_id"], ["registration_tokens.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_inventory_sync_runs_team_id", "inventory_sync_runs", ["team_id"])
+    op.create_index("ix_inventory_sync_runs_source_id", "inventory_sync_runs", ["source_id"])
+
+    op.create_table(
+        "audit_events",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("team_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("actor_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("actor_type", sa.String(length=20), nullable=False),
+        sa.Column("actor_label", sa.String(length=320), nullable=True),
+        sa.Column("action", sa.String(length=80), nullable=False),
+        sa.Column("resource_type", sa.String(length=40), nullable=False),
+        sa.Column("resource_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("resource_name", sa.String(length=320), nullable=True),
+        sa.Column("before_data", postgresql.JSONB(), nullable=True),
+        sa.Column("after_data", postgresql.JSONB(), nullable=True),
+        sa.Column("context", postgresql.JSONB(), nullable=False),
+        sa.Column("inventory_source_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("sync_run_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    for column in ("team_id", "actor_user_id", "action", "resource_type", "resource_id", "created_at"):
+        op.create_index(f"ix_audit_events_{column}", "audit_events", [column])
+
+    op.add_column("nodes", sa.Column("inventory_source_id", postgresql.UUID(as_uuid=True), nullable=True))
+    op.add_column("nodes", sa.Column("external_id", sa.String(length=255), nullable=True))
+    op.create_foreign_key(
+        "fk_nodes_inventory_source_id", "nodes", "inventory_sources",
+        ["inventory_source_id"], ["id"], ondelete="SET NULL",
+    )
+    op.create_index("ix_nodes_inventory_source", "nodes", ["team_id", "inventory_source_id"])
+    op.create_index(
+        "uq_nodes_source_external_id", "nodes", ["inventory_source_id", "external_id"],
+        unique=True, postgresql_where=sa.text("external_id is not null"),
+    )
+    op.add_column("registration_tokens", sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("registration_tokens", "last_used_at")
+    op.drop_index("uq_nodes_source_external_id", table_name="nodes")
+    op.drop_index("ix_nodes_inventory_source", table_name="nodes")
+    op.drop_constraint("fk_nodes_inventory_source_id", "nodes", type_="foreignkey")
+    op.drop_column("nodes", "external_id")
+    op.drop_column("nodes", "inventory_source_id")
+    for column in ("created_at", "resource_id", "resource_type", "action", "actor_user_id", "team_id"):
+        op.drop_index(f"ix_audit_events_{column}", table_name="audit_events")
+    op.drop_table("audit_events")
+    op.drop_index("ix_inventory_sync_runs_source_id", table_name="inventory_sync_runs")
+    op.drop_index("ix_inventory_sync_runs_team_id", table_name="inventory_sync_runs")
+    op.drop_table("inventory_sync_runs")
+    op.drop_index("ix_inventory_sources_team_id", table_name="inventory_sources")
+    op.drop_table("inventory_sources")

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
 from app.api.routes import (
+    accountability,
     admin,
     api_tokens,
     auth,
@@ -22,3 +23,5 @@ api_router.include_router(invites.router)
 api_router.include_router(registration_tokens.router)
 api_router.include_router(register_node.router)
 api_router.include_router(admin.router)
+api_router.include_router(accountability.machine_router)
+api_router.include_router(accountability.team_router)

--- a/backend/app/api/routes/accountability.py
+++ b/backend/app/api/routes/accountability.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user
+from app.api.routes.register_node import _validate_token
+from app.core.rate_limit import rate_limit_register_nodes_batch
+from app.core.rbac import require_role
+from app.db.session import get_db
+from app.models.inventory_source import InventorySource
+from app.models.inventory_sync_run import InventorySyncRun
+from app.models.registration_token import RegistrationToken
+from app.models.user import User
+from app.schemas.accountability import (
+    AuditEventPage,
+    InventorySourcePage,
+    InventorySyncApplyRequest,
+    InventorySyncApplyResponse,
+    InventorySyncHumanApplyRequest,
+    InventorySyncPreview,
+    InventorySyncPreviewRequest,
+    InventorySyncRunDetail,
+    InventorySyncRunPublic,
+)
+from app.services.audit import list_audit_events, record_audit_event
+from app.services.inventory_sync import (
+    apply_sync_run,
+    create_sync_preview,
+    get_sync_run_for_apply,
+    get_team_sync_run,
+    list_inventory_sources,
+    list_source_runs,
+)
+
+machine_router = APIRouter(prefix="/inventory-sync", tags=["inventory-sync"])
+team_router = APIRouter(prefix="/teams/{team_id}", tags=["accountability"])
+
+
+@machine_router.post("/preview", response_model=InventorySyncPreview, status_code=201)
+async def preview_inventory_sync(
+    payload: InventorySyncPreviewRequest,
+    db: AsyncSession = Depends(get_db),
+    _rl: None = Depends(rate_limit_register_nodes_batch),
+) -> dict:
+    rt = await _validate_token(db, payload.token)
+    try:
+        run = await create_sync_preview(db, rt=rt, payload=payload)
+        await db.commit()
+        await db.refresh(run, attribute_names=["source"])
+    except ValueError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {
+        "run_id": run.id,
+        "source": run.source,
+        "status": run.status,
+        "expires_at": run.expires_at,
+        "reconcile_missing": run.reconcile_missing,
+        "summary": run.summary,
+        "changes": run.changes,
+    }
+
+
+@machine_router.post("/{run_id}/apply", response_model=InventorySyncApplyResponse)
+async def apply_inventory_sync(
+    run_id: uuid.UUID,
+    payload: InventorySyncApplyRequest,
+    db: AsyncSession = Depends(get_db),
+    _rl: None = Depends(rate_limit_register_nodes_batch),
+) -> InventorySyncApplyResponse:
+    rt = await _validate_token(db, payload.token)
+    run = await get_sync_run_for_apply(db, run_id=run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail="Sync preview not found")
+    if run.team_id != rt.team_id:
+        await db.rollback()
+        raise HTTPException(status_code=403, detail="Registration token does not belong to this sync run")
+    if run.status != "previewed":
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="This sync preview has already been applied or closed")
+    if run.expires_at <= datetime.now(timezone.utc):
+        run.status = "expired"
+        await db.commit()
+        raise HTTPException(status_code=409, detail="This sync preview has expired; create a new preview")
+    try:
+        counts = await apply_sync_run(db, run=run, rt=rt, retire_missing=payload.retire_missing)
+        await db.commit()
+        return InventorySyncApplyResponse(run_id=run.id, status="applied", summary=counts)
+    except PermissionError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except ValueError as exc:
+        await db.rollback()
+        failed = await db.get(InventorySyncRun, run_id)
+        if failed:
+            failed.status = "failed"
+            source = await db.get(InventorySource, failed.source_id)
+            if source:
+                source.last_attempt_at = datetime.now(timezone.utc)
+                source.last_failure_at = datetime.now(timezone.utc)
+                source.last_error = str(exc)[:2000]
+                await record_audit_event(
+                    db, team_id=failed.team_id, actor_type="automation", actor_label=source.name,
+                    action="inventory_sync.failed", resource_type="inventory_sync_run",
+                    resource_id=failed.id, resource_name=source.name,
+                    context={"error": str(exc)[:500]}, inventory_source_id=source.id,
+                    sync_run_id=failed.id,
+                )
+            await db.commit()
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@team_router.get("/audit-events", response_model=AuditEventPage)
+async def audit_events(
+    team_id: uuid.UUID,
+    action: str | None = Query(default=None, max_length=80),
+    resource_type: str | None = Query(default=None, max_length=40),
+    actor_type: str | None = Query(default=None, pattern="^(user|automation|system)$"),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> AuditEventPage:
+    await require_role(db, user=user, team_id=team_id, min_role="viewer")
+    total, events = await list_audit_events(
+        db, team_id=team_id, action=action, resource_type=resource_type,
+        actor_type=actor_type, limit=limit, offset=offset,
+    )
+    return AuditEventPage(total=total, events=events)
+
+
+@team_router.get("/inventory-sources", response_model=InventorySourcePage)
+async def inventory_sources(
+    team_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> InventorySourcePage:
+    await require_role(db, user=user, team_id=team_id, min_role="viewer")
+    return InventorySourcePage(sources=await list_inventory_sources(db, team_id=team_id))
+
+
+@team_router.get(
+    "/inventory-sources/{source_id}/runs", response_model=list[InventorySyncRunPublic]
+)
+async def inventory_source_runs(
+    team_id: uuid.UUID,
+    source_id: uuid.UUID,
+    limit: int = Query(default=25, ge=1, le=100),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[InventorySyncRun]:
+    await require_role(db, user=user, team_id=team_id, min_role="viewer")
+    return await list_source_runs(db, team_id=team_id, source_id=source_id, limit=limit)
+
+
+@team_router.get("/inventory-sync-runs/{run_id}", response_model=InventorySyncRunDetail)
+async def inventory_sync_run_detail(
+    team_id: uuid.UUID,
+    run_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> InventorySyncRun:
+    await require_role(db, user=user, team_id=team_id, min_role="viewer")
+    run = await get_team_sync_run(db, team_id=team_id, run_id=run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail="Sync run not found")
+    return run
+
+
+@team_router.post(
+    "/inventory-sync-runs/{run_id}/apply", response_model=InventorySyncApplyResponse
+)
+async def apply_inventory_sync_as_user(
+    team_id: uuid.UUID,
+    run_id: uuid.UUID,
+    payload: InventorySyncHumanApplyRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> InventorySyncApplyResponse:
+    await require_role(db, user=user, team_id=team_id, min_role="admin")
+    run = await get_team_sync_run(db, team_id=team_id, run_id=run_id, lock=True)
+    if not run:
+        raise HTTPException(status_code=404, detail="Sync run not found")
+    if run.status != "previewed":
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="This sync preview has already been applied or closed")
+    if run.expires_at <= datetime.now(timezone.utc):
+        run.status = "expired"
+        await db.commit()
+        raise HTTPException(status_code=409, detail="This sync preview has expired; create a new preview")
+    if not run.registration_token_id:
+        raise HTTPException(status_code=409, detail="The registration credential for this preview no longer exists")
+    rt = await db.get(RegistrationToken, run.registration_token_id)
+    if not rt or not rt.is_active or rt.is_expired:
+        raise HTTPException(status_code=409, detail="The registration credential for this preview is no longer usable")
+    try:
+        counts = await apply_sync_run(
+            db, run=run, rt=rt, retire_missing=payload.retire_missing,
+            actor_type="user", actor_user_id=user.id, actor_label=user.email,
+        )
+        await db.commit()
+        return InventorySyncApplyResponse(run_id=run.id, status="applied", summary=counts)
+    except ValueError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail=str(exc)) from exc

--- a/backend/app/api/routes/admin.py
+++ b/backend/app/api/routes/admin.py
@@ -29,9 +29,10 @@ from app.schemas.admin import (
     AdminUserRow,
     AdminUserUpdate,
 )
-from app.services.users import get_user_by_email
 from app.services.api_tokens import revoke_all_api_tokens
+from app.services.audit import record_audit_event
 from app.services.refresh_sessions import revoke_all_refresh_sessions
+from app.services.users import get_user_by_email
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -120,7 +121,7 @@ async def admin_list_users(
 @router.post("/users", response_model=AdminUserRow, status_code=status.HTTP_201_CREATED)
 async def admin_create_user(
     payload: AdminCreateUser,
-    _su: User = Depends(require_superuser),
+    su: User = Depends(require_superuser),
     db: AsyncSession = Depends(get_db),
 ) -> AdminUserRow:
     existing = await get_user_by_email(db, payload.email)
@@ -135,6 +136,12 @@ async def admin_create_user(
     )
     db.add(user)
     await db.flush()
+    await record_audit_event(
+        db, team_id=None, actor_type="user", actor_user_id=su.id, actor_label=su.email,
+        action="admin.user_created", resource_type="user", resource_id=user.id,
+        resource_name=user.email, after_data={"email": user.email,
+        "is_superuser": user.is_superuser, "is_active": user.is_active},
+    )
     await db.commit()
 
     user = await _load_user(db, user.id)
@@ -159,6 +166,8 @@ async def admin_update_user(
     db: AsyncSession = Depends(get_db),
 ) -> AdminUserRow:
     target = await _load_user(db, user_id)
+    before = {"email": target.email, "full_name": target.full_name,
+              "is_active": target.is_active, "is_superuser": target.is_superuser}
 
     if target.id == su.id:
         if payload.is_active is False:
@@ -184,6 +193,15 @@ async def admin_update_user(
         await revoke_all_api_tokens(db, user_id=target.id)
         await revoke_all_refresh_sessions(db, user_id=target.id)
 
+    await record_audit_event(
+        db, team_id=None, actor_type="user", actor_user_id=su.id, actor_label=su.email,
+        action="admin.user_updated", resource_type="user", resource_id=target.id,
+        resource_name=target.email, before_data=before,
+        after_data={"email": target.email, "full_name": target.full_name,
+                    "is_active": target.is_active, "is_superuser": target.is_superuser,
+                    "password_changed": payload.new_password is not None},
+    )
+
     await db.commit()
     target = await _load_user(db, user_id)
     return await _user_to_row(target)
@@ -201,7 +219,13 @@ async def admin_delete_user(
     target = result.scalar_one_or_none()
     if not target:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    target_email = target.email
     await db.delete(target)
+    await record_audit_event(
+        db, team_id=None, actor_type="user", actor_user_id=su.id, actor_label=su.email,
+        action="admin.user_deleted", resource_type="user", resource_id=user_id,
+        resource_name=target_email, before_data={"email": target_email},
+    )
     await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
@@ -247,7 +271,7 @@ async def admin_list_teams(
 @router.post("/teams", response_model=AdminTeamRow, status_code=status.HTTP_201_CREATED)
 async def admin_create_team(
     payload: AdminCreateTeam,
-    _su: User = Depends(require_superuser),
+    su: User = Depends(require_superuser),
     db: AsyncSession = Depends(get_db),
 ) -> AdminTeamRow:
     owner = (await db.execute(select(User).where(User.id == payload.owner_user_id))).scalar_one_or_none()
@@ -265,6 +289,13 @@ async def admin_create_team(
 
     membership = Membership(user_id=owner.id, team_id=team.id, role="owner")
     db.add(membership)
+    await db.flush()
+    await record_audit_event(
+        db, team_id=team.id, actor_type="user", actor_user_id=su.id, actor_label=su.email,
+        action="admin.team_created", resource_type="team", resource_id=team.id,
+        resource_name=team.name, after_data={"name": team.name, "slug": team.slug,
+                                             "owner_user_id": str(owner.id)},
+    )
     await db.commit()
 
     return await _team_row(db, team)
@@ -303,12 +334,13 @@ async def admin_get_team(
 async def admin_update_team(
     team_id: uuid.UUID,
     payload: AdminTeamUpdate,
-    _su: User = Depends(require_superuser),
+    su: User = Depends(require_superuser),
     db: AsyncSession = Depends(get_db),
 ) -> AdminTeamRow:
     team = (await db.execute(select(Team).where(Team.id == team_id))).scalar_one_or_none()
     if not team:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")
+    before = {"name": team.name, "slug": team.slug}
 
     if payload.name is not None:
         team.name = payload.name
@@ -318,6 +350,13 @@ async def admin_update_team(
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Slug already in use")
         team.slug = payload.slug
 
+    await record_audit_event(
+        db, team_id=team_id, actor_type="user", actor_user_id=su.id, actor_label=su.email,
+        action="admin.team_updated", resource_type="team", resource_id=team.id,
+        resource_name=team.name, before_data=before,
+        after_data={"name": team.name, "slug": team.slug},
+    )
+
     await db.commit()
     await db.refresh(team)
     return await _team_row(db, team)
@@ -326,14 +365,20 @@ async def admin_update_team(
 @router.delete("/teams/{team_id}", status_code=status.HTTP_204_NO_CONTENT, response_class=Response)
 async def admin_delete_team(
     team_id: uuid.UUID,
-    _su: User = Depends(require_superuser),
+    su: User = Depends(require_superuser),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     result = await db.execute(select(Team).where(Team.id == team_id))
     target = result.scalar_one_or_none()
     if not target:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")
+    target_name = target.name
     await db.delete(target)
+    await record_audit_event(
+        db, team_id=team_id, actor_type="user", actor_user_id=su.id, actor_label=su.email,
+        action="admin.team_deleted", resource_type="team", resource_id=team_id,
+        resource_name=target_name, before_data={"name": target_name, "slug": target.slug},
+    )
     await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
@@ -346,7 +391,7 @@ async def admin_delete_team(
 async def admin_add_member(
     team_id: uuid.UUID,
     payload: AdminAddMember,
-    _su: User = Depends(require_superuser),
+    su: User = Depends(require_superuser),
     db: AsyncSession = Depends(get_db),
 ) -> AdminMemberRow:
     team = (await db.execute(select(Team).where(Team.id == team_id))).scalar_one_or_none()
@@ -365,6 +410,13 @@ async def admin_add_member(
 
     membership = Membership(user_id=user.id, team_id=team_id, role=payload.role)
     db.add(membership)
+    await db.flush()
+    await record_audit_event(
+        db, team_id=team_id, actor_type="user", actor_user_id=su.id, actor_label=su.email,
+        action="admin.membership_added", resource_type="membership",
+        resource_id=membership.id, resource_name=user.email,
+        after_data={"user_id": str(user.id), "role": membership.role},
+    )
     await db.commit()
     await db.refresh(membership)
 
@@ -379,7 +431,7 @@ async def admin_update_member(
     team_id: uuid.UUID,
     membership_id: uuid.UUID,
     payload: AdminUpdateMemberRole,
-    _su: User = Depends(require_superuser),
+    su: User = Depends(require_superuser),
     db: AsyncSession = Depends(get_db),
 ) -> AdminMemberRow:
     result = await db.execute(
@@ -391,7 +443,14 @@ async def admin_update_member(
     if not membership:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Membership not found")
 
+    old_role = membership.role
     membership.role = payload.role
+    await record_audit_event(
+        db, team_id=team_id, actor_type="user", actor_user_id=su.id, actor_label=su.email,
+        action="admin.membership_role_changed", resource_type="membership",
+        resource_id=membership.id, resource_name=membership.user.email,
+        before_data={"role": old_role}, after_data={"role": payload.role},
+    )
     await db.commit()
     await db.refresh(membership)
 
@@ -405,15 +464,24 @@ async def admin_update_member(
 async def admin_remove_member(
     team_id: uuid.UUID,
     membership_id: uuid.UUID,
-    _su: User = Depends(require_superuser),
+    su: User = Depends(require_superuser),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     result = await db.execute(
-        select(Membership).where(Membership.id == membership_id, Membership.team_id == team_id)
+        select(Membership).options(selectinload(Membership.user))
+        .where(Membership.id == membership_id, Membership.team_id == team_id)
     )
     membership = result.scalar_one_or_none()
     if not membership:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Membership not found")
+    member_email = membership.user.email
+    member_role = membership.role
     await db.delete(membership)
+    await record_audit_event(
+        db, team_id=team_id, actor_type="user", actor_user_id=su.id, actor_label=su.email,
+        action="admin.membership_removed", resource_type="membership",
+        resource_id=membership.id, resource_name=member_email,
+        before_data={"user_id": str(membership.user_id), "role": member_role},
+    )
     await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/routes/api_tokens.py
+++ b/backend/app/api/routes/api_tokens.py
@@ -10,6 +10,7 @@ from app.db.session import get_db
 from app.models.user import User
 from app.schemas.api_tokens import ApiTokenCreate, ApiTokenCreated, ApiTokenPublic
 from app.services.api_tokens import create_api_token, list_api_tokens, revoke_api_token
+from app.services.audit import record_audit_event
 
 router = APIRouter(prefix="/auth/api-tokens", tags=["auth"])
 
@@ -34,6 +35,13 @@ async def create_token(
         name=payload.name,
         expires_in_days=payload.expires_in_days,
     )
+    await record_audit_event(
+        db, team_id=None, actor_type="user", actor_user_id=user.id,
+        actor_label=user.email, action="api_token.created", resource_type="api_token",
+        resource_id=api_token.id, resource_name=api_token.name,
+        after_data={"name": api_token.name, "token_prefix": api_token.token_prefix,
+                    "expires_at": str(api_token.expires_at) if api_token.expires_at else None},
+    )
     await db.commit()
     await db.refresh(api_token)
     public = ApiTokenPublic.model_validate(api_token)
@@ -49,4 +57,11 @@ async def revoke_token(
     api_token = await revoke_api_token(db, user_id=user.id, token_id=token_id)
     if api_token is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="API token not found")
+    await record_audit_event(
+        db, team_id=None, actor_type="user", actor_user_id=user.id,
+        actor_label=user.email, action="api_token.revoked", resource_type="api_token",
+        resource_id=api_token.id, resource_name=api_token.name,
+        before_data={"revoked_at": None},
+        after_data={"revoked_at": str(api_token.revoked_at)},
+    )
     await db.commit()

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -25,6 +25,7 @@ from app.schemas.auth import (
 )
 from app.schemas.users import UserPublic, UserUpdate
 from app.services.api_tokens import revoke_all_api_tokens
+from app.services.audit import record_audit_event
 from app.services.invites import accept_invite, get_invite_by_token
 from app.services.refresh_sessions import (
     RefreshSessionError,
@@ -118,7 +119,13 @@ async def register(
     user = await create_user(db, email=email, password=payload.password, full_name=payload.full_name)
 
     if invite:
-        await accept_invite(db, invite=invite, user_id=user.id)
+        membership = await accept_invite(db, invite=invite, user_id=user.id)
+        await record_audit_event(
+            db, team_id=invite.team_id, actor_type="user", actor_user_id=user.id,
+            actor_label=user.email, action="invite.accepted", resource_type="membership",
+            resource_id=membership.id, resource_name=user.email,
+            after_data={"role": membership.role, "invite_id": str(invite.id)},
+        )
     else:
         if not payload.team_name or len(payload.team_name.strip()) < 2:
             raise HTTPException(status_code=400, detail="Team name is required")
@@ -131,7 +138,15 @@ async def register(
             slug = f"{base_slug}-{i+1}"
         else:
             raise HTTPException(status_code=500, detail="Could not allocate team slug")
-        await create_team_with_owner(db, name=payload.team_name.strip(), slug=slug, owner_user_id=user.id)
+        team = await create_team_with_owner(
+            db, name=payload.team_name.strip(), slug=slug, owner_user_id=user.id
+        )
+        await record_audit_event(
+            db, team_id=team.id, actor_type="user", actor_user_id=user.id,
+            actor_label=user.email, action="team.created", resource_type="team",
+            resource_id=team.id, resource_name=team.name,
+            after_data={"name": team.name, "slug": team.slug},
+        )
 
     access = create_access_token(user_id=user.id)
     ip, user_agent = _request_metadata(request)

--- a/backend/app/api/routes/invites.py
+++ b/backend/app/api/routes/invites.py
@@ -11,7 +11,14 @@ from app.core.rbac import require_role
 from app.db.session import get_db
 from app.models.user import User
 from app.schemas.invites import InviteCreate, InviteCreated, InviteInfo, InvitePublic
-from app.services.invites import accept_invite, create_invite, get_invite_by_token, list_invites, revoke_invite
+from app.services.audit import record_audit_event
+from app.services.invites import (
+    accept_invite,
+    create_invite,
+    get_invite_by_token,
+    list_invites,
+    revoke_invite,
+)
 
 router = APIRouter(tags=["invites"])
 
@@ -45,6 +52,13 @@ async def create_team_invite(
         role=payload.role,
         invited_by_id=user.id,
     )
+    await record_audit_event(
+        db, team_id=team_id, actor_type="user", actor_user_id=user.id,
+        actor_label=user.email, action="invite.created", resource_type="invite",
+        resource_id=invite.id, resource_name=invite.invited_email,
+        after_data={"email": invite.invited_email, "role": invite.role,
+                    "expires_at": str(invite.expires_at)},
+    )
     await db.commit()
     await db.refresh(invite, ["invited_by"])
     return _invite_to_public(invite, token)
@@ -74,6 +88,7 @@ async def revoke_team_invite(
 ) -> Response:
     await require_role(db, user=user, team_id=team_id, min_role="admin")
     from sqlalchemy import select
+
     from app.models.invite import Invite
 
     res = await db.execute(
@@ -83,6 +98,11 @@ async def revoke_team_invite(
     if not invite:
         raise HTTPException(status_code=404, detail="Invite not found")
     await revoke_invite(db, invite=invite)
+    await record_audit_event(
+        db, team_id=team_id, actor_type="user", actor_user_id=user.id,
+        actor_label=user.email, action="invite.revoked", resource_type="invite",
+        resource_id=invite.id, resource_name=invite.invited_email,
+    )
     await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
@@ -128,5 +148,11 @@ async def accept_team_invite(
         raise HTTPException(status_code=400, detail="Invite has expired")
 
     membership = await accept_invite(db, invite=invite, user_id=user.id)
+    await record_audit_event(
+        db, team_id=invite.team_id, actor_type="user", actor_user_id=user.id,
+        actor_label=user.email, action="invite.accepted", resource_type="membership",
+        resource_id=membership.id, resource_name=user.email,
+        after_data={"role": membership.role, "invite_id": str(invite.id)},
+    )
     await db.commit()
     return {"message": "Invite accepted", "team_id": str(invite.team_id), "role": membership.role}

--- a/backend/app/api/routes/members.py
+++ b/backend/app/api/routes/members.py
@@ -10,7 +10,13 @@ from app.core.rbac import VALID_ROLES, has_role, require_role, role_level
 from app.db.session import get_db
 from app.models.user import User
 from app.schemas.members import MemberPublic, MemberRoleUpdate
-from app.services.members import get_membership, list_members, remove_member, update_member_role
+from app.services.audit import record_audit_event
+from app.services.members import (
+    get_membership,
+    list_members,
+    remove_member,
+    update_member_role,
+)
 
 router = APIRouter(prefix="/teams/{team_id}/members", tags=["members"])
 
@@ -60,7 +66,14 @@ async def change_member_role(
     if not has_role(actor, "owner") and role_level(target.role) >= role_level(actor.role):
         raise HTTPException(status_code=403, detail="Cannot modify a member with equal or higher role")
 
+    old_role = target.role
     target = await update_member_role(db, membership=target, role=payload.role)
+    await record_audit_event(
+        db, team_id=team_id, actor_type="user", actor_user_id=user.id,
+        actor_label=user.email, action="membership.role_changed", resource_type="membership",
+        resource_id=target.id, resource_name=target.user.email,
+        before_data={"role": old_role}, after_data={"role": payload.role},
+    )
     await db.commit()
     await db.refresh(target, ["user"])
     return _member_to_public(target)
@@ -92,6 +105,15 @@ async def remove_team_member(
     if not has_role(actor, "owner") and role_level(target.role) >= role_level(actor.role):
         raise HTTPException(status_code=403, detail="Cannot remove a member with equal or higher role")
 
+    member_email = target.user.email
+    member_role = target.role
+    member_user_id = target.user_id
     await remove_member(db, membership=target)
+    await record_audit_event(
+        db, team_id=team_id, actor_type="user", actor_user_id=user.id,
+        actor_label=user.email, action="membership.removed", resource_type="membership",
+        resource_id=target.id, resource_name=member_email,
+        before_data={"role": member_role, "user_id": str(member_user_id)},
+    )
     await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/routes/nodes.py
+++ b/backend/app/api/routes/nodes.py
@@ -25,16 +25,17 @@ from app.schemas.nodes import (
     StaleReviewQueue,
 )
 from app.services.ansible_inventory import build_ansible_inventory
+from app.services.audit import node_snapshot, record_audit_event
 from app.services.nodes import (
+    apply_stale_review_decision,
     bulk_delete_nodes,
     bulk_update_tags,
-    apply_stale_review_decision,
     count_nodes,
     create_node,
     delete_node,
+    get_node,
     get_node_stats,
     get_stale_review_queue,
-    get_node,
     list_nodes,
     update_node,
     validate_parent_node_id,
@@ -109,6 +110,11 @@ async def nodes_create(
         raise HTTPException(status_code=400, detail=str(e)) from e
 
     node = await create_node(db, team_id=team_id, data=data)
+    await record_audit_event(
+        db, team_id=team_id, actor_type="user", actor_user_id=user.id,
+        actor_label=user.email, action="node.created", resource_type="node",
+        resource_id=node.id, resource_name=node.name, after_data=node_snapshot(node),
+    )
     await db.commit()
     created = await get_node(db, team_id=team_id, node_id=node.id)
     if created is None:  # pragma: no cover - defensive after a successful insert
@@ -124,7 +130,15 @@ async def nodes_bulk_delete(
     db: AsyncSession = Depends(get_db),
 ) -> BulkActionResponse:
     await require_role(db, user=user, team_id=team_id, min_role="member")
+    rows = await db.execute(select(Node).where(Node.team_id == team_id, Node.id.in_(payload.node_ids)))
+    snapshots = [node_snapshot(node) for node in rows.scalars().all()]
     affected = await bulk_delete_nodes(db, team_id=team_id, node_ids=payload.node_ids)
+    await record_audit_event(
+        db, team_id=team_id, actor_type="user", actor_user_id=user.id,
+        actor_label=user.email, action="node.bulk_deleted", resource_type="node_batch",
+        resource_name=f"{affected} nodes", before_data={"nodes": snapshots},
+        context={"affected": affected},
+    )
     await db.commit()
     return BulkActionResponse(affected=affected)
 
@@ -143,6 +157,14 @@ async def nodes_bulk_tag(
         node_ids=payload.node_ids,
         add=payload.add or None,
         remove=payload.remove or None,
+    )
+    await record_audit_event(
+        db, team_id=team_id, actor_type="user", actor_user_id=user.id,
+        actor_label=user.email, action="node.bulk_tagged", resource_type="node_batch",
+        resource_name=f"{affected} nodes", context={
+            "node_ids": [str(node_id) for node_id in payload.node_ids],
+            "add": payload.add, "remove": payload.remove, "affected": affected,
+        },
     )
     await db.commit()
     return BulkActionResponse(affected=affected)
@@ -226,6 +248,15 @@ async def stale_review_decide(
         reviewed_by_id=user.id,
         owner_user_id=payload.owner_user_id,
     )
+    await record_audit_event(
+        db, team_id=team_id, actor_type="user", actor_user_id=user.id,
+        actor_label=user.email, action="node.stale_review_decided",
+        resource_type="node_batch", resource_name=f"{affected} nodes",
+        context={"node_ids": [str(node_id) for node_id in payload.node_ids],
+                 "lifecycle_status": payload.lifecycle_status,
+                 "owner_user_id": str(payload.owner_user_id) if payload.owner_user_id else None,
+                 "affected": affected},
+    )
     await db.commit()
     return BulkActionResponse(affected=affected)
 
@@ -257,6 +288,7 @@ async def nodes_patch(
     if not node:
         raise HTTPException(status_code=404, detail="Node not found")
     data = payload.model_dump(exclude_unset=True)
+    before = node_snapshot(node)
 
     if "parent_node_id" in data:
         try:
@@ -270,6 +302,12 @@ async def nodes_patch(
             raise HTTPException(status_code=400, detail=str(e)) from e
 
     node = await update_node(db, node=node, data=data)
+    await record_audit_event(
+        db, team_id=team_id, actor_type="user", actor_user_id=user.id,
+        actor_label=user.email, action="node.updated", resource_type="node",
+        resource_id=node.id, resource_name=node.name, before_data=before,
+        after_data=node_snapshot(node),
+    )
     await db.commit()
     updated = await get_node(db, team_id=team_id, node_id=node.id)
     if updated is None:  # pragma: no cover - defensive after a successful update
@@ -288,6 +326,12 @@ async def nodes_delete(
     node = await get_node(db, team_id=team_id, node_id=node_id)
     if not node:
         raise HTTPException(status_code=404, detail="Node not found")
+    before = node_snapshot(node)
     await delete_node(db, node=node)
+    await record_audit_event(
+        db, team_id=team_id, actor_type="user", actor_user_id=user.id,
+        actor_label=user.email, action="node.deleted", resource_type="node",
+        resource_id=node.id, resource_name=node.name, before_data=before,
+    )
     await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/routes/register_node.py
+++ b/backend/app/api/routes/register_node.py
@@ -20,6 +20,7 @@ from app.schemas.registration_tokens import (
     BatchNodeResult,
     NodeRegisterRequest,
 )
+from app.services.audit import node_snapshot, record_audit_event
 from app.services.registration_tokens import (
     get_registration_token_by_value,
     register_or_update_node_with_token,
@@ -63,6 +64,13 @@ async def register_node(
 
     if not created:
         response.status_code = 200
+
+    await record_audit_event(
+        db, team_id=rt.team_id, actor_type="automation", actor_label=rt.label,
+        action="node.created" if created else "node.updated", resource_type="node",
+        resource_id=node.id, resource_name=node.name, after_data=node_snapshot(node),
+        context={"registration_token_id": str(rt.id), "endpoint": "register-node"},
+    )
 
     await db.commit()
     result = await db.execute(
@@ -132,6 +140,13 @@ async def register_nodes_batch(
             status="created" if was_created else "updated",
             node_id=node.id,
         ))
+
+        await record_audit_event(
+            db, team_id=rt.team_id, actor_type="automation", actor_label=rt.label,
+            action="node.created" if was_created else "node.updated", resource_type="node",
+            resource_id=node.id, resource_name=node.name, after_data=node_snapshot(node),
+            context={"registration_token_id": str(rt.id), "endpoint": "register-nodes"},
+        )
 
     await db.commit()
 

--- a/backend/app/api/routes/registration_tokens.py
+++ b/backend/app/api/routes/registration_tokens.py
@@ -14,6 +14,7 @@ from app.schemas.registration_tokens import (
     RegistrationTokenCreated,
     RegistrationTokenPublic,
 )
+from app.services.audit import record_audit_event
 from app.services.registration_tokens import (
     create_registration_token,
     get_registration_token_by_id,
@@ -37,6 +38,7 @@ def _to_public(
         "use_count": rt.use_count,
         "allowed_kinds": rt.allowed_kinds,
         "expires_at": rt.expires_at,
+        "last_used_at": rt.last_used_at,
         "is_active": rt.is_active,
         "is_usable": rt.is_usable,
         "created_at": rt.created_at,
@@ -59,6 +61,14 @@ async def create_token(
         max_uses=payload.max_uses,
         allowed_kinds=payload.allowed_kinds,
         expires_in_days=payload.expires_in_days,
+    )
+    await record_audit_event(
+        db, team_id=team_id, actor_type="user", actor_user_id=user.id,
+        actor_label=user.email, action="registration_token.created",
+        resource_type="registration_token", resource_id=rt.id, resource_name=rt.label,
+        after_data={"label": rt.label, "token_prefix": rt.token_prefix,
+                    "max_uses": rt.max_uses, "allowed_kinds": rt.allowed_kinds,
+                    "expires_at": str(rt.expires_at) if rt.expires_at else None},
     )
     await db.commit()
     return _to_public(rt, created_by_email=user.email, token=token)
@@ -87,5 +97,11 @@ async def revoke_token(
     if not rt:
         raise HTTPException(status_code=404, detail="Token not found")
     await revoke_registration_token(db, rt=rt)
+    await record_audit_event(
+        db, team_id=team_id, actor_type="user", actor_user_id=user.id,
+        actor_label=user.email, action="registration_token.revoked",
+        resource_type="registration_token", resource_id=rt.id, resource_name=rt.label,
+        before_data={"is_active": True}, after_data={"is_active": False},
+    )
     await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/routes/teams.py
+++ b/backend/app/api/routes/teams.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -10,7 +10,8 @@ from app.db.session import get_db
 from app.models.team import Team
 from app.models.user import User
 from app.schemas.teams import TeamCreate, TeamPublic
-from app.services.teams import create_team_with_owner, list_teams_for_user
+from app.services.audit import record_audit_event
+from app.services.teams import create_team_with_owner
 
 router = APIRouter(prefix="/teams", tags=["teams"])
 
@@ -37,6 +38,11 @@ async def create_team(
         raise HTTPException(status_code=500, detail="Could not allocate team slug")
 
     team = await create_team_with_owner(db, name=payload.name, slug=slug, owner_user_id=user.id)
+    await record_audit_event(
+        db, team_id=team.id, actor_type="user", actor_user_id=user.id,
+        actor_label=user.email, action="team.created", resource_type="team",
+        resource_id=team.id, resource_name=team.name,
+        after_data={"name": team.name, "slug": team.slug},
+    )
     await db.commit()
     return team
-

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,9 +1,12 @@
 from app.models.api_token import ApiToken
+from app.models.audit_event import AuditEvent
+from app.models.inventory_source import InventorySource
+from app.models.inventory_sync_run import InventorySyncRun
 from app.models.invite import Invite
 from app.models.membership import Membership
 from app.models.node import Node
-from app.models.registration_token import RegistrationToken
 from app.models.refresh_session import RefreshSession
+from app.models.registration_token import RegistrationToken
 from app.models.team import Team
 from app.models.user import User
 
@@ -16,4 +19,7 @@ __all__ = [
     "RegistrationToken",
     "ApiToken",
     "RefreshSession",
+    "AuditEvent",
+    "InventorySource",
+    "InventorySyncRun",
 ]

--- a/backend/app/models/audit_event.py
+++ b/backend/app/models/audit_event.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+from app.models.common import UUIDPrimaryKeyMixin
+
+
+class AuditEvent(Base, UUIDPrimaryKeyMixin):
+    """Immutable record of a human or automation mutation."""
+
+    __tablename__ = "audit_events"
+
+    # Deliberately not foreign keys: audit evidence must survive deletion of the
+    # referenced team, user, source, run, or resource.
+    team_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
+    actor_user_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
+    actor_type: Mapped[str] = mapped_column(String(20), nullable=False)  # user|automation|system
+    actor_label: Mapped[str | None] = mapped_column(String(320), nullable=True)
+    action: Mapped[str] = mapped_column(String(80), nullable=False, index=True)
+    resource_type: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    resource_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
+    resource_name: Mapped[str | None] = mapped_column(String(320), nullable=True)
+    before_data: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    after_data: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    context: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    inventory_source_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    sync_run_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
+    )

--- a/backend/app/models/inventory_source.py
+++ b/backend/app/models/inventory_source.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+from app.models.common import TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class InventorySource(Base, UUIDPrimaryKeyMixin, TimestampMixin):
+    __tablename__ = "inventory_sources"
+    __table_args__ = (UniqueConstraint("team_id", "source_key", name="uq_inventory_sources_team_key"),)
+
+    team_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    registration_token_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("registration_tokens.id", ondelete="SET NULL"), nullable=True
+    )
+    created_by_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    source_key: Mapped[str] = mapped_column(String(160), nullable=False)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    source_type: Mapped[str] = mapped_column(String(40), nullable=False)
+    expected_interval_minutes: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1440, server_default=text("1440")
+    )
+    last_attempt_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_success_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_failure_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_summary: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict, server_default=text("'{}'::jsonb"))
+
+    team: Mapped["Team"] = relationship()
+    registration_token: Mapped["RegistrationToken | None"] = relationship()
+    created_by: Mapped["User | None"] = relationship()
+
+    @property
+    def health_status(self) -> str:
+        if self.last_failure_at and (not self.last_success_at or self.last_failure_at > self.last_success_at):
+            return "failing"
+        if not self.last_success_at:
+            return "never"
+        due = self.last_success_at + timedelta(minutes=max(self.expected_interval_minutes, 1) * 2)
+        return "stale" if due < datetime.now(timezone.utc) else "healthy"
+
+
+from app.models.registration_token import RegistrationToken  # noqa: E402
+from app.models.team import Team  # noqa: E402
+from app.models.user import User  # noqa: E402

--- a/backend/app/models/inventory_sync_run.py
+++ b/backend/app/models/inventory_sync_run.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+from app.models.common import TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class InventorySyncRun(Base, UUIDPrimaryKeyMixin, TimestampMixin):
+    __tablename__ = "inventory_sync_runs"
+
+    team_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    source_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("inventory_sources.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    registration_token_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("registration_tokens.id", ondelete="SET NULL"), nullable=True
+    )
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="previewed")
+    reconcile_missing: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=text("true"))
+    proposed_nodes: Mapped[list] = mapped_column(JSONB, nullable=False)
+    changes: Mapped[list] = mapped_column(JSONB, nullable=False)
+    summary: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    applied_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    source: Mapped["InventorySource"] = relationship()
+
+
+from app.models.inventory_source import InventorySource  # noqa: E402

--- a/backend/app/models/node.py
+++ b/backend/app/models/node.py
@@ -16,6 +16,11 @@ class Node(Base, UUIDPrimaryKeyMixin, TimestampMixin):
 
     team_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("teams.id"), nullable=False, index=True)
 
+    inventory_source_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("inventory_sources.id", ondelete="SET NULL"), nullable=True
+    )
+    external_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
     parent_node_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("nodes.id", ondelete="SET NULL"),
@@ -63,6 +68,7 @@ class Node(Base, UUIDPrimaryKeyMixin, TimestampMixin):
     )
     reviewed_by: Mapped["User | None"] = relationship(foreign_keys=[reviewed_by_id])
     owner: Mapped["User | None"] = relationship(foreign_keys=[owner_user_id])
+    inventory_source: Mapped["InventorySource | None"] = relationship()
 
     @property
     def owner_email(self) -> str | None:
@@ -73,5 +79,6 @@ class Node(Base, UUIDPrimaryKeyMixin, TimestampMixin):
         return self.reviewed_by.email if self.reviewed_by else None
 
 
+from app.models.inventory_source import InventorySource  # noqa: E402
 from app.models.team import Team  # noqa: E402
 from app.models.user import User  # noqa: E402

--- a/backend/app/models/registration_token.py
+++ b/backend/app/models/registration_token.py
@@ -31,6 +31,7 @@ class RegistrationToken(Base, UUIDPrimaryKeyMixin, TimestampMixin):
     allowed_kinds: Mapped[list[str] | None] = mapped_column(JSONB, nullable=True)
 
     expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=text("true"))
 
     team: Mapped["Team"] = relationship()

--- a/backend/app/schemas/accountability.py
+++ b/backend/app/schemas/accountability.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from app.schemas.registration_tokens import NodeRegisterItem
+
+
+class AuditEventPublic(BaseModel):
+    id: uuid.UUID
+    team_id: uuid.UUID | None
+    actor_user_id: uuid.UUID | None
+    actor_type: str
+    actor_label: str | None
+    action: str
+    resource_type: str
+    resource_id: uuid.UUID | None
+    resource_name: str | None
+    before_data: dict | None
+    after_data: dict | None
+    context: dict
+    inventory_source_id: uuid.UUID | None
+    sync_run_id: uuid.UUID | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class AuditEventPage(BaseModel):
+    total: int
+    events: list[AuditEventPublic]
+
+
+class InventorySourcePublic(BaseModel):
+    id: uuid.UUID
+    team_id: uuid.UUID
+    source_key: str
+    name: str
+    source_type: str
+    expected_interval_minutes: int
+    health_status: str
+    last_attempt_at: datetime | None
+    last_success_at: datetime | None
+    last_failure_at: datetime | None
+    last_error: str | None
+    last_summary: dict
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class InventorySyncChange(BaseModel):
+    action: str  # create|update|unchanged|missing
+    node_id: uuid.UUID | None = None
+    external_id: str | None = None
+    name: str
+    hostname: str | None = None
+    changed_fields: list[str] = Field(default_factory=list)
+
+
+class InventorySyncPreviewRequest(BaseModel):
+    token: str
+    source_key: str = Field(min_length=1, max_length=160, pattern=r"^[A-Za-z0-9._:-]+$")
+    source_name: str = Field(min_length=1, max_length=200)
+    source_type: str = Field(min_length=1, max_length=40, pattern=r"^[A-Za-z0-9._-]+$")
+    expected_interval_minutes: int = Field(default=1440, ge=5, le=525600)
+    reconcile_missing: bool = True
+    nodes: list[NodeRegisterItem] = Field(max_length=1000)
+
+
+class InventorySyncPreview(BaseModel):
+    run_id: uuid.UUID
+    source: InventorySourcePublic
+    status: str
+    expires_at: datetime
+    reconcile_missing: bool
+    summary: dict[str, int]
+    changes: list[InventorySyncChange]
+
+
+class InventorySyncApplyRequest(BaseModel):
+    token: str
+    retire_missing: bool = False
+
+
+class InventorySyncHumanApplyRequest(BaseModel):
+    retire_missing: bool = False
+
+
+class InventorySyncApplyResponse(BaseModel):
+    run_id: uuid.UUID
+    status: str
+    summary: dict[str, int]
+
+
+class InventorySourcePage(BaseModel):
+    sources: list[InventorySourcePublic]
+
+
+class InventorySyncRunPublic(BaseModel):
+    id: uuid.UUID
+    source_id: uuid.UUID
+    status: str
+    reconcile_missing: bool
+    summary: dict
+    expires_at: datetime
+    applied_at: datetime | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class InventorySyncRunDetail(InventorySyncRunPublic):
+    source: InventorySourcePublic
+    changes: list[InventorySyncChange]

--- a/backend/app/schemas/nodes.py
+++ b/backend/app/schemas/nodes.py
@@ -16,6 +16,7 @@ class NodeCreate(BaseModel):
     tags: list[str] = Field(default_factory=list)
     meta: dict = Field(default_factory=dict)
     notes: str | None = None
+    external_id: str | None = Field(default=None, max_length=255)
 
 
 class NodeUpdate(BaseModel):
@@ -30,12 +31,15 @@ class NodeUpdate(BaseModel):
     notes: str | None = None
     last_seen_at: datetime | None = None
     last_seen_source: str | None = Field(default=None, max_length=100)
+    external_id: str | None = Field(default=None, max_length=255)
 
 
 class NodePublic(BaseModel):
     id: uuid.UUID
     team_id: uuid.UUID
     parent_node_id: uuid.UUID | None
+    inventory_source_id: uuid.UUID | None
+    external_id: str | None
     kind: str
     name: str
     hostname: str | None

--- a/backend/app/schemas/registration_tokens.py
+++ b/backend/app/schemas/registration_tokens.py
@@ -23,6 +23,7 @@ class RegistrationTokenPublic(BaseModel):
     use_count: int
     allowed_kinds: list[str] | None
     expires_at: datetime | None
+    last_used_at: datetime | None
     is_active: bool
     is_usable: bool
     created_at: datetime
@@ -57,6 +58,7 @@ class NodeRegisterItem(BaseModel):
     tags: list[str] = Field(default_factory=list)
     meta: dict = Field(default_factory=dict)
     notes: str | None = None
+    external_id: str | None = Field(default=None, max_length=255)
 
 
 class BatchNodeRegisterRequest(BaseModel):

--- a/backend/app/services/audit.py
+++ b/backend/app/services/audit.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.audit_event import AuditEvent
+from app.models.node import Node
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, (uuid.UUID, datetime)):
+        return str(value)
+    if isinstance(value, dict):
+        return {str(k): _json_value(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_value(v) for v in value]
+    return value
+
+
+def node_snapshot(node: Node) -> dict:
+    return _json_value({
+        "id": node.id,
+        "name": node.name,
+        "kind": node.kind,
+        "hostname": node.hostname,
+        "ip": node.ip,
+        "url": node.url,
+        "tags": node.tags,
+        "meta": node.meta,
+        "notes": node.notes,
+        "parent_node_id": node.parent_node_id,
+        "inventory_source_id": node.inventory_source_id,
+        "external_id": node.external_id,
+        "lifecycle_status": node.lifecycle_status,
+        "owner_user_id": node.owner_user_id,
+        "last_seen_at": node.last_seen_at,
+        "last_seen_source": node.last_seen_source,
+    })
+
+
+async def record_audit_event(
+    db: AsyncSession,
+    *,
+    team_id: uuid.UUID | None,
+    actor_type: str,
+    action: str,
+    resource_type: str,
+    actor_user_id: uuid.UUID | None = None,
+    actor_label: str | None = None,
+    resource_id: uuid.UUID | None = None,
+    resource_name: str | None = None,
+    before_data: dict | None = None,
+    after_data: dict | None = None,
+    context: dict | None = None,
+    inventory_source_id: uuid.UUID | None = None,
+    sync_run_id: uuid.UUID | None = None,
+) -> AuditEvent:
+    event = AuditEvent(
+        team_id=team_id,
+        actor_user_id=actor_user_id,
+        actor_type=actor_type,
+        actor_label=actor_label,
+        action=action,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        resource_name=resource_name,
+        before_data=_json_value(before_data),
+        after_data=_json_value(after_data),
+        context=_json_value(context or {}),
+        inventory_source_id=inventory_source_id,
+        sync_run_id=sync_run_id,
+    )
+    db.add(event)
+    await db.flush()
+    return event
+
+
+async def list_audit_events(
+    db: AsyncSession,
+    *,
+    team_id: uuid.UUID,
+    action: str | None = None,
+    resource_type: str | None = None,
+    actor_type: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> tuple[int, list[AuditEvent]]:
+    filters = [AuditEvent.team_id == team_id]
+    if action:
+        filters.append(AuditEvent.action == action)
+    if resource_type:
+        filters.append(AuditEvent.resource_type == resource_type)
+    if actor_type:
+        filters.append(AuditEvent.actor_type == actor_type)
+    total = await db.scalar(select(func.count()).select_from(AuditEvent).where(*filters))
+    result = await db.execute(
+        select(AuditEvent)
+        .where(*filters)
+        .order_by(AuditEvent.created_at.desc(), AuditEvent.id.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    return int(total or 0), list(result.scalars().all())

--- a/backend/app/services/inventory_sync.py
+++ b/backend/app/services/inventory_sync.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+
+from app.models.inventory_source import InventorySource
+from app.models.inventory_sync_run import InventorySyncRun
+from app.models.node import Node
+from app.models.registration_token import RegistrationToken
+from app.schemas.accountability import InventorySyncPreviewRequest
+from app.services.audit import node_snapshot, record_audit_event
+from app.services.registration_tokens import register_or_update_node_with_token
+
+SYNC_FIELDS = ("name", "kind", "hostname", "ip", "url", "tags", "meta", "notes", "external_id")
+
+
+def _incoming_snapshot(data: dict) -> dict:
+    return {field: data.get(field) for field in SYNC_FIELDS}
+
+
+def _changed_fields(node: Node, data: dict) -> list[str]:
+    changed: list[str] = []
+    for field in SYNC_FIELDS:
+        incoming = data.get(field)
+        current = getattr(node, field)
+        if field == "tags":
+            if sorted(current or []) != sorted(incoming or []):
+                changed.append(field)
+        elif field == "meta":
+            if (current or {}) != (incoming or {}):
+                changed.append(field)
+        elif current != incoming:
+            changed.append(field)
+    return changed
+
+
+async def get_or_create_source(
+    db: AsyncSession, *, rt: RegistrationToken, payload: InventorySyncPreviewRequest
+) -> InventorySource:
+    result = await db.execute(
+        select(InventorySource)
+        .where(InventorySource.team_id == rt.team_id)
+        .where(InventorySource.source_key == payload.source_key)
+    )
+    source = result.scalar_one_or_none()
+    if source is None:
+        source = InventorySource(
+            team_id=rt.team_id,
+            registration_token_id=rt.id,
+            created_by_id=rt.created_by_id,
+            source_key=payload.source_key,
+            name=payload.source_name,
+            source_type=payload.source_type,
+            expected_interval_minutes=payload.expected_interval_minutes,
+        )
+        db.add(source)
+    else:
+        source.registration_token_id = rt.id
+        source.name = payload.source_name
+        source.source_type = payload.source_type
+        source.expected_interval_minutes = payload.expected_interval_minutes
+    await db.flush()
+    return source
+
+
+async def create_sync_preview(
+    db: AsyncSession, *, rt: RegistrationToken, payload: InventorySyncPreviewRequest
+) -> InventorySyncRun:
+    now = datetime.now(timezone.utc)
+    source = await get_or_create_source(db, rt=rt, payload=payload)
+    result = await db.execute(select(Node).where(Node.team_id == rt.team_id))
+    team_nodes = list(result.scalars().all())
+
+    by_source_external = {
+        (node.inventory_source_id, node.external_id): node
+        for node in team_nodes if node.external_id
+    }
+    by_hostname = {node.hostname: node for node in team_nodes if node.hostname}
+    by_name = {node.name: node for node in team_nodes}
+    matched_ids: set[uuid.UUID] = set()
+    changes: list[dict] = []
+    proposed: list[dict] = []
+
+    for item in payload.nodes:
+        if rt.allowed_kinds and item.kind not in rt.allowed_kinds:
+            raise ValueError(f"Kind '{item.kind}' is not allowed by this registration token")
+        data = item.model_dump(mode="json")
+        node = None
+        if item.external_id:
+            node = by_source_external.get((source.id, item.external_id))
+        if node is None and item.hostname:
+            node = by_hostname.get(item.hostname)
+        if node is None:
+            node = by_name.get(item.name)
+        if node and node.inventory_source_id not in (None, source.id):
+            raise ValueError(
+                f"Node '{node.name}' is already managed by another inventory source"
+            )
+        if node and node.id in matched_ids:
+            raise ValueError(f"Multiple input records resolve to node '{node.name}'")
+        proposed.append(data)
+        if node is None:
+            changes.append({
+                "action": "create", "node_id": None, "external_id": item.external_id,
+                "name": item.name, "hostname": item.hostname, "changed_fields": list(SYNC_FIELDS),
+            })
+        else:
+            matched_ids.add(node.id)
+            fields = _changed_fields(node, data)
+            if node.inventory_source_id != source.id:
+                fields.append("inventory_source_id")
+            changes.append({
+                "action": "update" if fields else "unchanged", "node_id": str(node.id),
+                "external_id": item.external_id, "name": item.name,
+                "hostname": item.hostname, "changed_fields": fields,
+            })
+
+    if payload.reconcile_missing:
+        for node in team_nodes:
+            if node.inventory_source_id == source.id and node.id not in matched_ids:
+                changes.append({
+                    "action": "missing", "node_id": str(node.id), "external_id": node.external_id,
+                    "name": node.name, "hostname": node.hostname, "changed_fields": [],
+                })
+
+    summary = {key: sum(1 for change in changes if change["action"] == key)
+               for key in ("create", "update", "unchanged", "missing")}
+    run = InventorySyncRun(
+        team_id=rt.team_id,
+        source_id=source.id,
+        registration_token_id=rt.id,
+        status="previewed",
+        reconcile_missing=payload.reconcile_missing,
+        proposed_nodes=proposed,
+        changes=changes,
+        summary=summary,
+        expires_at=now + timedelta(minutes=30),
+    )
+    db.add(run)
+    source.last_attempt_at = now
+    rt.last_used_at = now
+    await db.flush()
+    await record_audit_event(
+        db, team_id=rt.team_id, actor_type="automation", actor_label=source.name,
+        action="inventory_sync.previewed", resource_type="inventory_sync_run",
+        resource_id=run.id, resource_name=source.name, after_data=summary,
+        inventory_source_id=source.id, sync_run_id=run.id,
+    )
+    return run
+
+
+async def get_sync_run_for_apply(
+    db: AsyncSession, *, run_id: uuid.UUID
+) -> InventorySyncRun | None:
+    result = await db.execute(
+        select(InventorySyncRun)
+        .options(joinedload(InventorySyncRun.source))
+        .where(InventorySyncRun.id == run_id)
+        .with_for_update(of=InventorySyncRun)
+    )
+    return result.scalar_one_or_none()
+
+
+async def apply_sync_run(
+    db: AsyncSession, *, run: InventorySyncRun, rt: RegistrationToken, retire_missing: bool,
+    actor_type: str = "automation", actor_user_id: uuid.UUID | None = None,
+    actor_label: str | None = None,
+) -> dict[str, int]:
+    now = datetime.now(timezone.utc)
+    if run.status != "previewed":
+        raise ValueError("This sync preview has already been applied or closed")
+    if run.expires_at <= now:
+        run.status = "expired"
+        raise ValueError("This sync preview has expired; create a new preview")
+    if run.team_id != rt.team_id:
+        raise PermissionError("Registration token does not belong to this sync run")
+
+    counts = {"created": 0, "updated": 0, "unchanged": 0, "retired": 0}
+    input_changes = [change for change in run.changes if change["action"] != "missing"]
+    for data, preview_change in zip(run.proposed_nodes, input_changes, strict=True):
+        before = None
+        if preview_change.get("node_id"):
+            existing = await db.get(Node, uuid.UUID(preview_change["node_id"]))
+            if existing:
+                before = node_snapshot(existing)
+        node, created = await register_or_update_node_with_token(
+            db, rt=rt, data=dict(data), allow_create=not rt.is_exhausted
+        )
+        if node is None:
+            raise ValueError("Registration token usage limit prevents creating a previewed node")
+        expected_node_id = preview_change.get("node_id")
+        if expected_node_id and node.id != uuid.UUID(expected_node_id):
+            raise ValueError("Inventory changed after preview; create a new preview")
+        if not expected_node_id and not created:
+            raise ValueError("Inventory changed after preview; create a new preview")
+        node.inventory_source_id = run.source_id
+        node.external_id = data.get("external_id")
+        node.tags = list(data.get("tags") or [])
+        node.meta = dict(data.get("meta") or {})
+        if data.get("parent_hostname") and node.parent_node_id is None:
+            node.meta.setdefault("parent_hostname", data["parent_hostname"])
+        node.last_seen_source = f"sync:{run.source.source_key}"
+        await db.flush()
+        after = node_snapshot(node)
+        if created:
+            counts["created"] += 1
+            action = "node.created"
+        elif preview_change["action"] == "unchanged":
+            counts["unchanged"] += 1
+            continue
+        else:
+            counts["updated"] += 1
+            action = "node.updated"
+        await record_audit_event(
+            db, team_id=run.team_id, actor_type=actor_type,
+            actor_user_id=actor_user_id, actor_label=actor_label or run.source.name,
+            action=action, resource_type="node", resource_id=node.id, resource_name=node.name,
+            before_data=before, after_data=after, inventory_source_id=run.source_id,
+            sync_run_id=run.id,
+        )
+
+    if retire_missing:
+        for change in run.changes:
+            if change["action"] != "missing" or not change.get("node_id"):
+                continue
+            node = await db.get(Node, uuid.UUID(change["node_id"]))
+            if not node or node.inventory_source_id != run.source_id:
+                continue
+            before = node_snapshot(node)
+            node.lifecycle_status = "retired"
+            node.reviewed_at = now
+            await db.flush()
+            counts["retired"] += 1
+            await record_audit_event(
+                db, team_id=run.team_id, actor_type=actor_type,
+                actor_user_id=actor_user_id, actor_label=actor_label or run.source.name,
+                action="node.retired_missing", resource_type="node", resource_id=node.id,
+                resource_name=node.name, before_data=before, after_data=node_snapshot(node),
+                inventory_source_id=run.source_id, sync_run_id=run.id,
+            )
+
+    run.status = "applied"
+    run.applied_at = now
+    run.summary = {**run.summary, **counts, "retire_missing": int(retire_missing)}
+    run.source.last_attempt_at = now
+    run.source.last_success_at = now
+    run.source.last_error = None
+    run.source.last_summary = run.summary
+    rt.last_used_at = now
+    await db.flush()
+    await record_audit_event(
+        db, team_id=run.team_id, actor_type=actor_type,
+        actor_user_id=actor_user_id, actor_label=actor_label or run.source.name,
+        action="inventory_sync.applied", resource_type="inventory_sync_run",
+        resource_id=run.id, resource_name=run.source.name, after_data=run.summary,
+        inventory_source_id=run.source_id, sync_run_id=run.id,
+    )
+    return counts
+
+
+async def list_inventory_sources(db: AsyncSession, *, team_id: uuid.UUID) -> list[InventorySource]:
+    result = await db.execute(
+        select(InventorySource).where(InventorySource.team_id == team_id)
+        .order_by(InventorySource.name.asc())
+    )
+    return list(result.scalars().all())
+
+
+async def list_source_runs(
+    db: AsyncSession, *, team_id: uuid.UUID, source_id: uuid.UUID, limit: int = 25
+) -> list[InventorySyncRun]:
+    result = await db.execute(
+        select(InventorySyncRun)
+        .where(InventorySyncRun.team_id == team_id, InventorySyncRun.source_id == source_id)
+        .order_by(InventorySyncRun.created_at.desc()).limit(limit)
+    )
+    return list(result.scalars().all())
+
+
+async def get_team_sync_run(
+    db: AsyncSession, *, team_id: uuid.UUID, run_id: uuid.UUID, lock: bool = False
+) -> InventorySyncRun | None:
+    stmt = (
+        select(InventorySyncRun).options(joinedload(InventorySyncRun.source))
+        .where(InventorySyncRun.team_id == team_id, InventorySyncRun.id == run_id)
+    )
+    if lock:
+        stmt = stmt.with_for_update(of=InventorySyncRun)
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()

--- a/backend/app/services/registration_tokens.py
+++ b/backend/app/services/registration_tokens.py
@@ -7,9 +7,9 @@ from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
+from app.core.opaque_tokens import generate_opaque_token, hash_opaque_token
 from app.models.node import Node
 from app.models.registration_token import RegistrationToken
-from app.core.opaque_tokens import generate_opaque_token, hash_opaque_token
 
 REGISTRATION_TOKEN_PREFIX = "nb_reg_"  # nosec B105
 
@@ -164,6 +164,7 @@ async def register_or_update_node_with_token(
 
     existing = await _find_existing_node_for_registration(db, team_id=rt.team_id, data=data)
     now = datetime.now(timezone.utc)
+    rt.last_used_at = now
 
     if existing:
         # Update the existing node in-place.

--- a/backend/tests/test_accountability.py
+++ b/backend/tests/test_accountability.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from app.models.audit_event import AuditEvent
+from app.models.inventory_source import InventorySource
+from app.schemas.accountability import InventorySyncPreviewRequest
+from pydantic import ValidationError
+
+
+def test_audit_event_is_append_only_by_shape() -> None:
+    assert "updated_at" not in AuditEvent.__table__.columns
+    assert "before_data" in AuditEvent.__table__.columns
+    assert "after_data" in AuditEvent.__table__.columns
+
+
+def test_inventory_source_health_states() -> None:
+    source = InventorySource(
+        source_key="docker:host", name="Docker host", source_type="docker",
+        expected_interval_minutes=60,
+    )
+    assert source.health_status == "never"
+
+    source.last_success_at = datetime.now(timezone.utc)
+    assert source.health_status == "healthy"
+
+    source.last_success_at = datetime.now(timezone.utc) - timedelta(hours=3)
+    assert source.health_status == "stale"
+
+    source.last_failure_at = datetime.now(timezone.utc)
+    source.last_error = "collector failed"
+    assert source.health_status == "failing"
+
+
+def test_sync_preview_accepts_empty_authoritative_snapshot() -> None:
+    payload = InventorySyncPreviewRequest(
+        token="nb_reg_test", source_key="docker:host.example", source_name="Docker host",
+        source_type="docker", nodes=[],
+    )
+    assert payload.reconcile_missing is True
+    assert payload.nodes == []
+
+
+def test_sync_preview_rejects_unsafe_source_key() -> None:
+    with pytest.raises(ValidationError):
+        InventorySyncPreviewRequest(
+            token="nb_reg_test", source_key="../../other-team", source_name="bad",
+            source_type="docker", nodes=[],
+        )

--- a/docs/INVENTORY_ACCOUNTABILITY_2026-08-12.md
+++ b/docs/INVENTORY_ACCOUNTABILITY_2026-08-12.md
@@ -1,0 +1,37 @@
+# Inventory accountability, reconciliation, and automation health
+
+This release turns Nodebyte's collectors into accountable, source-scoped inventory
+workflows.
+
+## Behavior
+
+- Audit events are append-only records without an update API or `updated_at` field.
+  They retain actor identifiers, resource identity, before/after snapshots, source and
+  sync-run context, and timestamps. Secrets and raw credentials are never recorded.
+- A sync preview calculates creates, updates, unchanged records, and missing records
+  without mutating nodes. Previews expire after 30 minutes and can be applied once.
+- Missing records are scoped to nodes previously owned by the same inventory source.
+  Retirement occurs only when `retire_missing=true` is explicitly supplied.
+- Owners and admins can review and apply pending previews in the Automation UI. The
+  registration token is never sent to the browser.
+- Sources report healthy, stale, failing, or never-synced status from their expected
+  interval and latest success/failure timestamps.
+
+## Collector controls
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `NODEBYTE_SYNC_MODE` | `apply` | Use `preview` for a non-mutating dry run. |
+| `NODEBYTE_RETIRE_MISSING` | `0` | Set to `1` to retire source-owned missing records during apply. |
+| `NODEBYTE_RECONCILE_MISSING` | `1` | Set to `0` to omit missing-record comparison. |
+| `NODEBYTE_EXPECTED_INTERVAL_MINUTES` | `1440` | Expected collector cadence used by health evaluation. |
+
+## Integrity boundaries
+
+- Registration-token team scope is checked on preview and apply.
+- Human apply requires team admin or owner access.
+- Apply locks the run row and rejects replay, expiration, or a revoked/expired source
+  credential.
+- Node changes, sync status, source health, and audit events commit atomically.
+- External IDs are unique within a source when present; hostname/name fallback supports
+  existing inventories during first adoption.

--- a/frontend/src/app/dashboard/activity/page.tsx
+++ b/frontend/src/app/dashboard/activity/page.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Bot, RefreshCw, UserRound } from "lucide-react";
+
+import { useAuth } from "@/lib/auth";
+import { api, ApiError, type AuditEventPage } from "@/lib/api";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+
+function prettyAction(value: string) {
+  return value.replaceAll(".", " · ").replaceAll("_", " ");
+}
+
+export default function ActivityPage() {
+  const { activeTeam } = useAuth();
+  const [page, setPage] = useState<AuditEventPage | null>(null);
+  const [actorType, setActorType] = useState("");
+  const [resourceType, setResourceType] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const load = useCallback(async () => {
+    if (!activeTeam) return;
+    setLoading(true);
+    setError("");
+    try {
+      setPage(await api.accountability.auditEvents(activeTeam.id, {
+        actor_type: actorType || undefined,
+        resource_type: resourceType || undefined,
+        limit: 100,
+      }));
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Could not load activity");
+    } finally {
+      setLoading(false);
+    }
+  }, [activeTeam, actorType, resourceType]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(load, 0);
+    return () => window.clearTimeout(timer);
+  }, [load]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Activity</h1>
+          <p className="text-sm text-[hsl(var(--muted-foreground))]">An append-only history of human and automation changes.</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <select aria-label="Actor type" value={actorType} onChange={(event) => setActorType(event.target.value)} className="h-9 rounded-md border border-[hsl(var(--border))] bg-transparent px-3 text-sm">
+            <option value="">All actors</option><option value="user">People</option><option value="automation">Automation</option><option value="system">System</option>
+          </select>
+          <select aria-label="Resource type" value={resourceType} onChange={(event) => setResourceType(event.target.value)} className="h-9 rounded-md border border-[hsl(var(--border))] bg-transparent px-3 text-sm">
+            <option value="">All resources</option><option value="node">Nodes</option><option value="node_batch">Node batches</option><option value="membership">Memberships</option><option value="registration_token">Registration tokens</option><option value="inventory_sync_run">Sync runs</option>
+          </select>
+          <Button size="sm" variant="outline" onClick={load} disabled={loading}><RefreshCw className="mr-1.5 h-4 w-4" />Refresh</Button>
+        </div>
+      </div>
+
+      {error && <div className="rounded-md bg-red-50 p-3 text-sm text-red-700 dark:bg-red-950 dark:text-red-300">{error}</div>}
+      {loading ? <div className="flex justify-center py-16"><Spinner className="h-6 w-6" /></div> : !page?.events.length ? (
+        <div className="rounded-xl border border-dashed border-[hsl(var(--border))] py-16 text-center text-sm text-[hsl(var(--muted-foreground))]">No matching activity yet.</div>
+      ) : (
+        <div className="overflow-hidden rounded-xl border border-[hsl(var(--border))]">
+          {page.events.map((event) => (
+            <details key={event.id} className="group border-b border-[hsl(var(--border))] p-4 last:border-b-0">
+              <summary className="flex cursor-pointer list-none items-start gap-3">
+                <div className="mt-0.5 rounded-md bg-[hsl(var(--muted))] p-2">{event.actor_type === "automation" ? <Bot className="h-4 w-4" /> : <UserRound className="h-4 w-4" />}</div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2"><span className="font-medium">{event.resource_name || event.resource_type}</span><Badge variant="outline">{prettyAction(event.action)}</Badge></div>
+                  <div className="mt-1 text-xs text-[hsl(var(--muted-foreground))]">{event.actor_label || event.actor_type} · {new Date(event.created_at).toLocaleString()}</div>
+                </div>
+              </summary>
+              <div className="mt-3 grid gap-3 pl-11 lg:grid-cols-2">
+                {event.before_data && <div><div className="mb-1 text-xs font-medium">Before</div><pre className="max-h-64 overflow-auto rounded-md bg-[hsl(var(--muted))] p-3 text-xs">{JSON.stringify(event.before_data, null, 2)}</pre></div>}
+                {event.after_data && <div><div className="mb-1 text-xs font-medium">After</div><pre className="max-h-64 overflow-auto rounded-md bg-[hsl(var(--muted))] p-3 text-xs">{JSON.stringify(event.after_data, null, 2)}</pre></div>}
+                {Object.keys(event.context).length > 0 && <div><div className="mb-1 text-xs font-medium">Context</div><pre className="max-h-64 overflow-auto rounded-md bg-[hsl(var(--muted))] p-3 text-xs">{JSON.stringify(event.context, null, 2)}</pre></div>}
+              </div>
+            </details>
+          ))}
+        </div>
+      )}
+      {page && <p className="text-xs text-[hsl(var(--muted-foreground))]">Showing {page.events.length} of {page.total} events.</p>}
+    </div>
+  );
+}

--- a/frontend/src/app/dashboard/automation/page.tsx
+++ b/frontend/src/app/dashboard/automation/page.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { AlertTriangle, CheckCircle2, Clock3, RefreshCw, RadioTower } from "lucide-react";
+
+import { useAuth } from "@/lib/auth";
+import { api, ApiError, type InventorySourcePublic, type InventorySyncRunPublic, type InventorySyncRunDetail } from "@/lib/api";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
+
+const HEALTH = {
+  healthy: { label: "Healthy", icon: CheckCircle2, className: "text-green-700 dark:text-green-300" },
+  stale: { label: "Stale", icon: Clock3, className: "text-amber-700 dark:text-amber-300" },
+  failing: { label: "Failing", icon: AlertTriangle, className: "text-red-700 dark:text-red-300" },
+  never: { label: "Never synced", icon: RadioTower, className: "text-[hsl(var(--muted-foreground))]" },
+} as const;
+
+export default function AutomationPage() {
+  const { activeTeam } = useAuth();
+  const [sources, setSources] = useState<InventorySourcePublic[]>([]);
+  const [selected, setSelected] = useState<InventorySourcePublic | null>(null);
+  const [runs, setRuns] = useState<InventorySyncRunPublic[]>([]);
+  const [review, setReview] = useState<InventorySyncRunDetail | null>(null);
+  const [applying, setApplying] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const load = useCallback(async () => {
+    if (!activeTeam) return;
+    setLoading(true); setError("");
+    try {
+      const result = await api.accountability.sources(activeTeam.id);
+      setSources(result.sources);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Could not load automation health");
+    } finally { setLoading(false); }
+  }, [activeTeam]);
+
+  useEffect(() => { const timer = window.setTimeout(load, 0); return () => window.clearTimeout(timer); }, [load]);
+
+  async function choose(source: InventorySourcePublic) {
+    if (!activeTeam) return;
+    setSelected(source); setRuns([]);
+    try { setRuns(await api.accountability.sourceRuns(activeTeam.id, source.id)); }
+    catch (err) { setError(err instanceof ApiError ? err.message : "Could not load sync runs"); }
+  }
+
+  async function reviewRun(run: InventorySyncRunPublic) {
+    if (!activeTeam) return;
+    try { setReview(await api.accountability.syncRun(activeTeam.id, run.id)); }
+    catch (err) { setError(err instanceof ApiError ? err.message : "Could not load sync preview"); }
+  }
+
+  async function applyRun(retireMissing: boolean) {
+    if (!activeTeam || !review) return;
+    setApplying(true); setError("");
+    try {
+      await api.accountability.applySyncRun(activeTeam.id, review.id, retireMissing);
+      setReview(null);
+      if (selected) setRuns(await api.accountability.sourceRuns(activeTeam.id, selected.id));
+      const refreshed = await api.accountability.sources(activeTeam.id);
+      setSources(refreshed.sources);
+    } catch (err) { setError(err instanceof ApiError ? err.message : "Could not apply sync preview"); }
+    finally { setApplying(false); }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-end justify-between"><div><h1 className="text-2xl font-semibold tracking-tight">Automation health</h1><p className="text-sm text-[hsl(var(--muted-foreground))]">Know whether authoritative inventory sources are current and what each run changed.</p></div><Button size="sm" variant="outline" onClick={load} disabled={loading}><RefreshCw className="mr-1.5 h-4 w-4" />Refresh</Button></div>
+      {error && <div className="rounded-md bg-red-50 p-3 text-sm text-red-700 dark:bg-red-950 dark:text-red-300">{error}</div>}
+      {loading ? <div className="flex justify-center py-16"><Spinner className="h-6 w-6" /></div> : !sources.length ? <div className="rounded-xl border border-dashed border-[hsl(var(--border))] py-16 text-center"><RadioTower className="mx-auto mb-3 h-8 w-8 text-[hsl(var(--muted-foreground))]" /><p className="font-medium">No managed inventory sources yet.</p><p className="text-sm text-[hsl(var(--muted-foreground))]">Run an updated Docker, Kubernetes, or LXD collector to create one.</p></div> : <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">{sources.map((source) => { const state = HEALTH[source.health_status]; const Icon = state.icon; return <Card key={source.id} className={`cursor-pointer transition-shadow hover:shadow-md ${selected?.id === source.id ? "ring-2 ring-[hsl(var(--primary))]" : ""}`}><button className="w-full text-left" onClick={() => choose(source)}><CardContent className="space-y-3 pt-5"><div className="flex items-start justify-between gap-3"><div><div className="font-medium">{source.name}</div><div className="text-xs text-[hsl(var(--muted-foreground))]">{source.source_key}</div></div><Badge variant="outline">{source.source_type}</Badge></div><div className={`flex items-center gap-2 text-sm font-medium ${state.className}`}><Icon className="h-4 w-4" />{state.label}</div><div className="text-xs text-[hsl(var(--muted-foreground))]">Last success: {source.last_success_at ? new Date(source.last_success_at).toLocaleString() : "Never"}</div>{source.last_error && <div className="rounded bg-red-50 p-2 text-xs text-red-700 dark:bg-red-950 dark:text-red-300">{source.last_error}</div>}</CardContent></button></Card>; })}</div>}
+      {selected && <div className="space-y-3"><h2 className="text-lg font-semibold">Recent runs · {selected.name}</h2><div className="overflow-x-auto rounded-xl border border-[hsl(var(--border))]"><table className="w-full min-w-[760px] text-sm"><thead className="bg-[hsl(var(--muted))]"><tr><th className="px-4 py-3 text-left">Time</th><th className="px-4 py-3 text-left">Status</th><th className="px-4 py-3 text-left">Created</th><th className="px-4 py-3 text-left">Updated</th><th className="px-4 py-3 text-left">Missing</th><th className="px-4 py-3 text-left">Retired</th><th className="px-4 py-3 text-left"></th></tr></thead><tbody>{runs.map((run) => <tr key={run.id} className="border-t border-[hsl(var(--border))]"><td className="px-4 py-3">{new Date(run.created_at).toLocaleString()}</td><td className="px-4 py-3"><Badge variant="outline">{run.status}</Badge></td><td className="px-4 py-3">{String(run.summary.created ?? run.summary.create ?? 0)}</td><td className="px-4 py-3">{String(run.summary.updated ?? run.summary.update ?? 0)}</td><td className="px-4 py-3">{String(run.summary.missing ?? 0)}</td><td className="px-4 py-3">{String(run.summary.retired ?? 0)}</td><td className="px-4 py-3"><Button size="sm" variant="outline" onClick={() => reviewRun(run)}>Review</Button></td></tr>)}</tbody></table>{!runs.length && <div className="p-8 text-center text-sm text-[hsl(var(--muted-foreground))]">No sync runs found.</div>}</div></div>}
+      {review && <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" onClick={() => setReview(null)}><div className="max-h-[90vh] w-full max-w-4xl overflow-auto rounded-xl bg-[hsl(var(--background))] p-6 shadow-xl" onClick={(event) => event.stopPropagation()}><div className="flex items-start justify-between gap-3"><div><h2 className="text-xl font-semibold">Sync preview · {review.source.name}</h2><p className="text-sm text-[hsl(var(--muted-foreground))]">Created {new Date(review.created_at).toLocaleString()}</p></div><Badge variant="outline">{review.status}</Badge></div><div className="mt-5 grid gap-2 sm:grid-cols-4">{(["create", "update", "unchanged", "missing"] as const).map((key) => <Card key={key}><CardContent className="pt-4"><div className="text-2xl font-semibold">{String(review.summary[key] ?? 0)}</div><div className="text-xs capitalize text-[hsl(var(--muted-foreground))]">{key}</div></CardContent></Card>)}</div><div className="mt-5 overflow-x-auto rounded-lg border border-[hsl(var(--border))]"><table className="w-full min-w-[640px] text-sm"><thead className="bg-[hsl(var(--muted))]"><tr><th className="px-3 py-2 text-left">Action</th><th className="px-3 py-2 text-left">Node</th><th className="px-3 py-2 text-left">Changed fields</th></tr></thead><tbody>{review.changes.map((change, index) => <tr key={`${change.action}-${change.node_id || change.external_id || index}`} className="border-t border-[hsl(var(--border))]"><td className="px-3 py-2"><Badge variant="outline">{change.action}</Badge></td><td className="px-3 py-2"><div className="font-medium">{change.name}</div><div className="text-xs text-[hsl(var(--muted-foreground))]">{change.hostname || change.external_id || "—"}</div></td><td className="px-3 py-2 text-xs text-[hsl(var(--muted-foreground))]">{change.changed_fields.join(", ") || "—"}</td></tr>)}</tbody></table></div><div className="mt-5 flex flex-wrap justify-end gap-2"><Button variant="outline" onClick={() => setReview(null)}>Close</Button>{review.status === "previewed" && (activeTeam?.my_role === "owner" || activeTeam?.my_role === "admin") && <><Button variant="outline" disabled={applying} onClick={() => applyRun(false)}>Apply, keep missing</Button><Button disabled={applying} onClick={() => applyRun(true)} className="bg-red-600 text-white hover:bg-red-700">Apply and retire missing</Button></>}</div></div></div>}
+    </div>
+  );
+}

--- a/frontend/src/app/dashboard/layout.tsx
+++ b/frontend/src/app/dashboard/layout.tsx
@@ -19,6 +19,8 @@ import {
   UsersRound,
   Building2,
   Archive,
+  ScrollText,
+  RadioTower,
 } from "lucide-react";
 
 import { useAuth } from "@/lib/auth";
@@ -30,6 +32,8 @@ const NAV_ITEMS: readonly { href: string; label: string; icon: typeof LayoutDash
   { href: "/dashboard", label: "Overview", icon: LayoutDashboard, exact: true },
   { href: "/dashboard/nodes", label: "Nodes", icon: Server, exact: true },
   { href: "/dashboard/nodes/review", label: "Stale review", icon: Archive },
+  { href: "/dashboard/automation", label: "Automation", icon: RadioTower },
+  { href: "/dashboard/activity", label: "Activity", icon: ScrollText },
   { href: "/dashboard/team", label: "Team", icon: Users },
   { href: "/dashboard/tokens", label: "Tokens", icon: KeyRound },
   { href: "/dashboard/settings", label: "Settings", icon: Settings },

--- a/frontend/src/app/dashboard/tokens/page.tsx
+++ b/frontend/src/app/dashboard/tokens/page.tsx
@@ -217,6 +217,7 @@ export default function RegistrationTokensPage() {
                 <th className="hidden px-4 py-3 text-left font-medium sm:table-cell">Usage</th>
                 <th className="hidden px-4 py-3 text-left font-medium md:table-cell">Kinds</th>
                 <th className="hidden px-4 py-3 text-left font-medium md:table-cell">Expires</th>
+                <th className="hidden px-4 py-3 text-left font-medium lg:table-cell">Last used</th>
                 <th className="px-4 py-3 text-left font-medium">Status</th>
                 <th className="px-4 py-3 text-right font-medium">Actions</th>
               </tr>
@@ -251,6 +252,9 @@ export default function RegistrationTokensPage() {
                   </td>
                   <td className="hidden px-4 py-3 text-[hsl(var(--muted-foreground))] md:table-cell">
                     {rt.expires_at ? new Date(rt.expires_at).toLocaleDateString() : "Never"}
+                  </td>
+                  <td className="hidden px-4 py-3 text-[hsl(var(--muted-foreground))] lg:table-cell">
+                    {rt.last_used_at ? new Date(rt.last_used_at).toLocaleString() : "Never"}
                   </td>
                   <td className="px-4 py-3">
                     {rt.is_usable ? (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -124,6 +124,7 @@ export interface RegistrationTokenPublic {
   use_count: number;
   allowed_kinds: string[] | null;
   expires_at: string | null;
+  last_used_at: string | null;
   is_active: boolean;
   is_usable: boolean;
   created_at: string;
@@ -137,6 +138,8 @@ export interface NodePublic {
   id: string;
   team_id: string;
   parent_node_id: string | null;
+  inventory_source_id: string | null;
+  external_id: string | null;
   kind: string;
   name: string;
   hostname: string | null;
@@ -189,6 +192,71 @@ export interface StaleReviewSummary {
 export interface StaleReviewQueue {
   summary: StaleReviewSummary;
   nodes: NodePublic[];
+}
+
+export interface AuditEventPublic {
+  id: string;
+  team_id: string | null;
+  actor_user_id: string | null;
+  actor_type: "user" | "automation" | "system";
+  actor_label: string | null;
+  action: string;
+  resource_type: string;
+  resource_id: string | null;
+  resource_name: string | null;
+  before_data: Record<string, unknown> | null;
+  after_data: Record<string, unknown> | null;
+  context: Record<string, unknown>;
+  inventory_source_id: string | null;
+  sync_run_id: string | null;
+  created_at: string;
+}
+
+export interface AuditEventPage {
+  total: number;
+  events: AuditEventPublic[];
+}
+
+export interface InventorySourcePublic {
+  id: string;
+  team_id: string;
+  source_key: string;
+  name: string;
+  source_type: string;
+  expected_interval_minutes: number;
+  health_status: "healthy" | "stale" | "failing" | "never";
+  last_attempt_at: string | null;
+  last_success_at: string | null;
+  last_failure_at: string | null;
+  last_error: string | null;
+  last_summary: Record<string, number | boolean>;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface InventorySyncRunPublic {
+  id: string;
+  source_id: string;
+  status: string;
+  reconcile_missing: boolean;
+  summary: Record<string, number | boolean>;
+  expires_at: string;
+  applied_at: string | null;
+  created_at: string;
+}
+
+export interface InventorySyncChange {
+  action: "create" | "update" | "unchanged" | "missing";
+  node_id: string | null;
+  external_id: string | null;
+  name: string;
+  hostname: string | null;
+  changed_fields: string[];
+}
+
+export interface InventorySyncRunDetail extends InventorySyncRunPublic {
+  source: InventorySourcePublic;
+  changes: InventorySyncChange[];
 }
 
 export interface PublicSettings {
@@ -427,6 +495,33 @@ export const api = {
       a.click();
       a.remove();
       URL.revokeObjectURL(a.href);
+    },
+  },
+  accountability: {
+    auditEvents(teamId: string, params?: { actor_type?: string; resource_type?: string; action?: string; limit?: number; offset?: number }) {
+      const qs = new URLSearchParams();
+      if (params?.actor_type) qs.set("actor_type", params.actor_type);
+      if (params?.resource_type) qs.set("resource_type", params.resource_type);
+      if (params?.action) qs.set("action", params.action);
+      if (params?.limit) qs.set("limit", String(params.limit));
+      if (params?.offset) qs.set("offset", String(params.offset));
+      const query = qs.toString();
+      return request<AuditEventPage>(`/api/teams/${teamId}/audit-events${query ? `?${query}` : ""}`);
+    },
+    sources(teamId: string) {
+      return request<{ sources: InventorySourcePublic[] }>(`/api/teams/${teamId}/inventory-sources`);
+    },
+    sourceRuns(teamId: string, sourceId: string, limit = 25) {
+      return request<InventorySyncRunPublic[]>(`/api/teams/${teamId}/inventory-sources/${sourceId}/runs?limit=${limit}`);
+    },
+    syncRun(teamId: string, runId: string) {
+      return request<InventorySyncRunDetail>(`/api/teams/${teamId}/inventory-sync-runs/${runId}`);
+    },
+    applySyncRun(teamId: string, runId: string, retireMissing: boolean) {
+      return request<{ run_id: string; status: string; summary: Record<string, number> }>(`/api/teams/${teamId}/inventory-sync-runs/${runId}/apply`, {
+        method: "POST",
+        body: JSON.stringify({ retire_missing: retireMissing }),
+      });
     },
   },
   admin: {

--- a/scripts/docker-inventory.sh
+++ b/scripts/docker-inventory.sh
@@ -20,12 +20,14 @@ set -euo pipefail
 
 BASE_URL="${NODEBYTE_URL:?Set NODEBYTE_URL (e.g. https://nodebyte.example.com)}"
 API="${BASE_URL}/api/register-node"
-BATCH_API="${BASE_URL}/api/register-nodes"
 TOKEN="${NODEBYTE_TOKEN:?Set NODEBYTE_TOKEN before running this script}"
 KIND="${NODEBYTE_KIND:-device}"
 EXTRA_TAGS="${NODEBYTE_TAGS:-}"
 DOCKER_ALL="${DOCKER_ALL:-1}"
 NODEBYTE_BATCH="${NODEBYTE_BATCH:-1}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=inventory-sync-lib.sh
+source "${SCRIPT_DIR}/inventory-sync-lib.sh"
 
 MAX_NAME_LEN=200
 MAX_HOSTNAME_LEN=255
@@ -54,14 +56,15 @@ if [[ "$DOCKER_ALL" == "1" ]]; then
   PS_ARGS+=(-a)
 fi
 
-IDS="$(docker ps "${PS_ARGS[@]}" 2>/dev/null || true)"
-if [[ -z "${IDS//[[:space:]]/}" ]]; then
-  echo "No containers found."
+mapfile -t IDS < <(docker ps "${PS_ARGS[@]}" 2>/dev/null || true)
+if [[ "${#IDS[@]}" -eq 0 ]]; then
+  echo "No containers found. Previewing an empty authoritative inventory."
+  nodebyte_sync_batch '[]' "docker:${HOST_FQDN}" "Docker on ${HOST_FQDN}" "docker" >/dev/null
   exit 0
 fi
 
 echo "Inspecting containers..."
-INSPECT="$(docker inspect $IDS)"
+INSPECT="$(docker inspect "${IDS[@]}")"
 COUNT="$(echo "$INSPECT" | jq 'length')"
 
 echo "Found $COUNT container(s). Registering with Nodebyte..."
@@ -158,6 +161,7 @@ for row in $(echo "$INSPECT" | jq -r '.[] | @base64'); do
     --arg ip "$IP" \
     --argjson tags "$TAGS" \
     --argjson meta "$META" \
+    --arg external_id "$CID" \
     '{
       name: $name,
       kind: $kind,
@@ -165,6 +169,7 @@ for row in $(echo "$INSPECT" | jq -r '.[] | @base64'); do
       parent_hostname: $parent_hostname,
       tags: $tags,
       meta: $meta
+      ,external_id: $external_id
     }
     | if .ip == "" then del(.ip) else . end
     | if .parent_hostname == "" then del(.parent_hostname) else . end'
@@ -205,35 +210,14 @@ if [[ "$NODEBYTE_BATCH" == "1" ]]; then
   BATCH_COUNT="$(echo "$BATCH_ITEMS" | jq 'length')"
   if [[ "$BATCH_COUNT" != "0" ]]; then
     echo ""
-    echo "Sending batch of $BATCH_COUNT nodes..."
-
-    PAYLOAD="$(jq -n --arg token "$TOKEN" --argjson nodes "$BATCH_ITEMS" \
-      '{token: $token, nodes: $nodes}')"
-
-    RESP="$(curl -sS -X POST "$BATCH_API" \
-      -H "Content-Type: application/json" \
-      -d "$PAYLOAD" \
-      -w '\n%{http_code}')"
-
-    BODY="${RESP%$'\n'*}"
-    HTTP_CODE="${RESP##*$'\n'}"
-
-    if [[ "$HTTP_CODE" == "200" ]]; then
-      local_created="$(echo "$BODY" | jq '.created')"
-      local_updated="$(echo "$BODY" | jq '.updated')"
-      local_skipped="$(echo "$BODY" | jq '.skipped')"
-      local_errors="$(echo "$BODY" | jq '.errors')"
-      OK=$((local_created + local_updated))
-      FAIL=$((local_skipped + local_errors))
-      echo "  ✓ $local_created created, $local_updated updated, $local_skipped skipped, $local_errors errors"
+    echo "Previewing authoritative Docker inventory..."
+    if nodebyte_sync_batch "$BATCH_ITEMS" "docker:${HOST_FQDN}" "Docker on ${HOST_FQDN}" "docker" >/dev/null; then
+      OK=$BATCH_COUNT
     else
-      MSG="$(json_error_summary "$BODY")"
-      echo "  ✗ Batch failed (HTTP $HTTP_CODE): $MSG"
-      FAIL=$COUNT
+      FAIL=$BATCH_COUNT
     fi
   fi
 fi
 
 echo ""
 echo "Done. $OK ok, $FAIL failed (out of $COUNT)."
-

--- a/scripts/inventory-sync-lib.sh
+++ b/scripts/inventory-sync-lib.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Shared preview/apply transport for authoritative Nodebyte inventory collectors.
+
+nodebyte_sync_batch() {
+  local nodes_json="$1" source_key="$2" source_name="$3" source_type="$4"
+  local base_url="${NODEBYTE_URL:?Set NODEBYTE_URL}"
+  local token="${NODEBYTE_TOKEN:?Set NODEBYTE_TOKEN}"
+  local mode="${NODEBYTE_SYNC_MODE:-apply}"
+  local retire_missing="${NODEBYTE_RETIRE_MISSING:-0}"
+  local reconcile_missing="${NODEBYTE_RECONCILE_MISSING:-1}"
+  local interval="${NODEBYTE_EXPECTED_INTERVAL_MINUTES:-1440}"
+
+  if [[ "$mode" != "apply" && "$mode" != "preview" ]]; then
+    echo "Error: NODEBYTE_SYNC_MODE must be apply or preview." >&2
+    return 2
+  fi
+
+  local preview_payload preview_response preview_body preview_code run_id
+  preview_payload="$(jq -n \
+    --arg token "$token" --arg source_key "$source_key" --arg source_name "$source_name" \
+    --arg source_type "$source_type" --argjson expected_interval_minutes "$interval" \
+    --argjson reconcile_missing "$([[ "$reconcile_missing" == "1" ]] && echo true || echo false)" \
+    --argjson nodes "$nodes_json" \
+    '{token: $token, source_key: $source_key, source_name: $source_name,
+      source_type: $source_type, expected_interval_minutes: $expected_interval_minutes,
+      reconcile_missing: $reconcile_missing, nodes: $nodes}')"
+
+  preview_response="$(curl -sS --connect-timeout 10 --max-time 120 -X POST \
+    "${base_url}/api/inventory-sync/preview" -H "Content-Type: application/json" \
+    --data-binary @- -w '\n%{http_code}' <<<"$preview_payload")"
+  preview_body="${preview_response%$'\n'*}"
+  preview_code="${preview_response##*$'\n'}"
+  if [[ "$preview_code" != "201" ]]; then
+    echo "Inventory preview failed (HTTP $preview_code): $(echo "$preview_body" | jq -r '.detail // .' 2>/dev/null || echo "$preview_body")" >&2
+    return 1
+  fi
+
+  echo "Preview: $(echo "$preview_body" | jq -r '.summary | "\(.create) create, \(.update) update, \(.unchanged) unchanged, \(.missing) missing"')" >&2
+  if [[ "$mode" == "preview" ]]; then
+    echo "$preview_body"
+    return 0
+  fi
+
+  run_id="$(echo "$preview_body" | jq -r '.run_id')"
+  local apply_payload apply_response apply_body apply_code
+  apply_payload="$(jq -n --arg token "$token" \
+    --argjson retire_missing "$([[ "$retire_missing" == "1" ]] && echo true || echo false)" \
+    '{token: $token, retire_missing: $retire_missing}')"
+  apply_response="$(curl -sS --connect-timeout 10 --max-time 120 -X POST \
+    "${base_url}/api/inventory-sync/${run_id}/apply" -H "Content-Type: application/json" \
+    --data-binary @- -w '\n%{http_code}' <<<"$apply_payload")"
+  apply_body="${apply_response%$'\n'*}"
+  apply_code="${apply_response##*$'\n'}"
+  if [[ "$apply_code" != "200" ]]; then
+    echo "Inventory apply failed (HTTP $apply_code): $(echo "$apply_body" | jq -r '.detail // .' 2>/dev/null || echo "$apply_body")" >&2
+    return 1
+  fi
+  echo "Applied: $(echo "$apply_body" | jq -r '.summary | "\(.created) created, \(.updated) updated, \(.unchanged) unchanged, \(.retired) retired"')" >&2
+  echo "$apply_body"
+}

--- a/scripts/kubernetes-inventory.sh
+++ b/scripts/kubernetes-inventory.sh
@@ -26,10 +26,12 @@ set -euo pipefail
 
 BASE_URL="${NODEBYTE_URL:?Set NODEBYTE_URL (e.g. https://nodebyte.example.com)}"
 API="${BASE_URL}/api/register-node"
-BATCH_API="${BASE_URL}/api/register-nodes"
 TOKEN="${NODEBYTE_TOKEN:?Set NODEBYTE_TOKEN before running this script}"
 EXTRA_TAGS="${NODEBYTE_TAGS:-}"
 NODEBYTE_BATCH="${NODEBYTE_BATCH:-1}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=inventory-sync-lib.sh
+source "${SCRIPT_DIR}/inventory-sync-lib.sh"
 K8S_SKIP_SYSTEM="${K8S_SKIP_SYSTEM:-0}"
 K8S_NAMESPACES="${K8S_NAMESPACES:-}"
 K8S_RESOURCES="${K8S_RESOURCES:-nodes,namespaces,deployments,statefulsets,daemonsets,services,ingresses}"
@@ -159,30 +161,11 @@ flush_batch() {
   echo ""
   echo "Sending batch of $count nodes..."
 
-  PAYLOAD="$(jq -n --arg token "$TOKEN" --argjson nodes "$BATCH_ITEMS" \
-    '{token: $token, nodes: $nodes}')"
-
-  RESP="$(curl -sS -X POST "$BATCH_API" \
-    -H "Content-Type: application/json" \
-    -d "$PAYLOAD" \
-    -w '\n%{http_code}')"
-
-  BODY="${RESP%$'\n'*}"
-  HTTP_CODE="${RESP##*$'\n'}"
-
-  if [[ "$HTTP_CODE" == "200" ]]; then
-    local created updated skipped errors
-    created="$(echo "$BODY" | jq '.created')"
-    updated="$(echo "$BODY" | jq '.updated')"
-    skipped="$(echo "$BODY" | jq '.skipped')"
-    errors="$(echo "$BODY" | jq '.errors')"
-    OK=$((created + updated))
-    FAIL=$((skipped + errors))
-    echo "  ✓ $created created, $updated updated, $skipped skipped, $errors errors"
+  echo "Previewing authoritative Kubernetes inventory..."
+  if nodebyte_sync_batch "$BATCH_ITEMS" "kubernetes:${CLUSTER_NAME}" "Kubernetes ${CLUSTER_NAME}" "kubernetes" >/dev/null; then
+    OK=$count
   else
-    MSG="$(json_error_summary "$BODY")"
-    echo "  ✗ Batch failed (HTTP $HTTP_CODE): $MSG"
-    FAIL=$TOTAL
+    FAIL=$count
   fi
 
   BATCH_ITEMS='[]'

--- a/scripts/lxd-inventory.sh
+++ b/scripts/lxd-inventory.sh
@@ -16,12 +16,14 @@ set -euo pipefail
 
 BASE_URL="${NODEBYTE_URL:?Set NODEBYTE_URL (e.g. https://nodebyte.example.com)}"
 API="${BASE_URL}/api/register-node"
-BATCH_API="${BASE_URL}/api/register-nodes"
 TOKEN="${NODEBYTE_TOKEN:?Set NODEBYTE_TOKEN before running this script}"
 KIND="${NODEBYTE_KIND:-device}"
 EXTRA_TAGS="${NODEBYTE_TAGS:-}"
 REMOTE="${LXC_REMOTE:-}"
 NODEBYTE_BATCH="${NODEBYTE_BATCH:-1}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=inventory-sync-lib.sh
+source "${SCRIPT_DIR}/inventory-sync-lib.sh"
 BATCH_ITEMS='[]'
 
 for cmd in lxc jq curl; do
@@ -40,7 +42,8 @@ INSTANCES="$(lxc list "${PREFIX}" --format json 2>/dev/null)"
 
 COUNT="$(echo "$INSTANCES" | jq 'length')"
 if [[ "$COUNT" -eq 0 ]]; then
-  echo "No instances found."
+  echo "No instances found. Previewing an empty authoritative inventory."
+  nodebyte_sync_batch '[]' "lxd:${REMOTE:-local}:${LXD_HOST_FQDN}" "LXD ${REMOTE:-local} on ${LXD_HOST_FQDN}" "lxd" >/dev/null
   exit 0
 fi
 
@@ -120,6 +123,7 @@ for row in $(echo "$INSTANCES" | jq -r '.[] | @base64'); do
     --arg ip "$IP" \
     --argjson tags "$TAGS" \
     --argjson meta "$META" \
+    --arg external_id "${REMOTE:-local}:${NAME}" \
     '{
       name: $name,
       kind: $kind,
@@ -127,6 +131,7 @@ for row in $(echo "$INSTANCES" | jq -r '.[] | @base64'); do
       parent_hostname: $parent_hostname,
       tags: $tags,
       meta: $meta
+      ,external_id: $external_id
     }
     | if .ip == "" then del(.ip) else . end
     | if .parent_hostname == "" then del(.parent_hostname) else . end'
@@ -161,31 +166,11 @@ if [[ "$NODEBYTE_BATCH" == "1" ]]; then
   BATCH_COUNT="$(echo "$BATCH_ITEMS" | jq 'length')"
   if [[ "$BATCH_COUNT" != "0" ]]; then
     echo ""
-    echo "Sending batch of $BATCH_COUNT nodes..."
-
-    PAYLOAD="$(jq -n --arg token "$TOKEN" --argjson nodes "$BATCH_ITEMS" \
-      '{token: $token, nodes: $nodes}')"
-
-    RESP="$(curl -sS -X POST "$BATCH_API" \
-      -H "Content-Type: application/json" \
-      -d "$PAYLOAD" \
-      -w '\n%{http_code}')"
-
-    BODY="${RESP%$'\n'*}"
-    HTTP_CODE="${RESP##*$'\n'}"
-
-    if [[ "$HTTP_CODE" == "200" ]]; then
-      batch_created="$(echo "$BODY" | jq '.created')"
-      batch_updated="$(echo "$BODY" | jq '.updated')"
-      batch_skipped="$(echo "$BODY" | jq '.skipped')"
-      batch_errors="$(echo "$BODY" | jq '.errors')"
-      OK=$((batch_created + batch_updated))
-      FAIL=$((batch_skipped + batch_errors))
-      echo "  ✓ $batch_created created, $batch_updated updated, $batch_skipped skipped, $batch_errors errors"
+    echo "Previewing authoritative LXD inventory..."
+    if nodebyte_sync_batch "$BATCH_ITEMS" "lxd:${REMOTE:-local}:${LXD_HOST_FQDN}" "LXD ${REMOTE:-local} on ${LXD_HOST_FQDN}" "lxd" >/dev/null; then
+      OK=$BATCH_COUNT
     else
-      MSG="$(echo "$BODY" | jq -r '.detail // .' 2>/dev/null || echo "$BODY")"
-      echo "  ✗ Batch failed (HTTP $HTTP_CODE): $MSG"
-      FAIL=$COUNT
+      FAIL=$BATCH_COUNT
     fi
   fi
 fi


### PR DESCRIPTION
## Summary

- add append-only, team-scoped audit events for human and automation mutations
- add source-scoped inventory preview/apply reconciliation with explicit missing-node retirement
- add automation source health, sync-run history, Activity and Automation dashboard views
- upgrade Docker, LXD, and Kubernetes collectors to use the accountable workflow
- preserve existing inventory through migration `0007_inventory_accountability`

## Security and integrity boundaries

- registration-token team scope and admin/owner human apply are enforced
- previews are non-mutating, expire after 30 minutes, lock on apply, and reject replay
- one source cannot claim or retire another source's nodes
- apply rejects inventory drift after preview and commits node changes, source health, run state, and audit evidence atomically
- raw credentials are excluded from audit records and browser payloads

## Validation

- backend: `15 passed`
- frontend: ESLint and Next.js production build pass
- migrations: fresh upgrade and seeded `0006` to `0007` preservation proof pass
- real PostgreSQL/API workflow: preview non-mutation, create/update/missing retirement, healthy source, audit history, cross-source isolation, replay rejection
- Bandit, pip-audit, npm audit, ShellCheck, focused Ruff checks, changed-file Gitleaks, and `git diff --check` pass

## Tracking

Plane: `a85e9c3d-85d0-411b-b774-b8c601006e34`
